### PR TITLE
[#36] feat :  create cookie module.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.43.9",
         "react-router-dom": "^6.11.2",
+        "universal-cookie": "^4.0.4",
         "zod": "^3.21.4"
       },
       "devDependencies": {
@@ -7971,7 +7972,6 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -16903,6 +16903,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "dependencies": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
+      }
+    },
+    "node_modules/universal-cookie/node_modules/@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
+    },
     "node_modules/universalify": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
@@ -17083,9 +17097,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.5.tgz",
-      "integrity": "sha512-0gEnL9wiRFxgz40o/i/eTBwm+NEbpUeTWhzKrZDSdKm6nplj+z4lKz8ANDgildxHm47Vg8EUia0aicKbawUVVA==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz",
+      "integrity": "sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.17.5",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.43.9",
     "react-router-dom": "^6.11.2",
+    "universal-cookie": "^4.0.4",
     "zod": "^3.21.4"
   },
   "devDependencies": {

--- a/src/module/cookie/__test__/UniversalCookieManager.test.ts
+++ b/src/module/cookie/__test__/UniversalCookieManager.test.ts
@@ -1,0 +1,62 @@
+import { CookieChangeOptions } from "universal-cookie/cjs/types";
+import { describe, test, beforeEach, vi } from "vitest";
+
+import UniversalCookieManager from "../implement/UniversalCookieManager";
+
+const testData = {
+  COOKIE_KEY: "test key",
+  COOKIE_VALUE: "test value",
+  COOKIE_KEY2: "test key second",
+  COOKIE_VALUE2: "test value second",
+};
+
+const { COOKIE_KEY, COOKIE_VALUE, COOKIE_KEY2, COOKIE_VALUE2 } = testData;
+
+describe("UniversalCookieManager", () => {
+  let cookieManager: UniversalCookieManager;
+  let callback: (options: CookieChangeOptions) => void;
+
+  beforeEach(() => {
+    cookieManager = new UniversalCookieManager();
+
+    cookieManager.set(COOKIE_KEY, COOKIE_VALUE);
+    cookieManager.set(COOKIE_KEY2, COOKIE_VALUE2);
+
+    callback = vi.fn();
+
+    cookieManager.addChangeListener(callback);
+  });
+
+  test("set으로 쿠키 설정 할수 있어야한다.", () => {
+    expect(cookieManager).not.toBeUndefined();
+  });
+
+  test("get으로 쿠키를 가져올수 있어야한다.", () => {
+    expect(cookieManager.get(COOKIE_KEY)).toBe(COOKIE_VALUE);
+  });
+
+  test("getAll으로 모든 쿠키를 가져올수 있어야한다.", () => {
+    const allCookies = cookieManager.getAll();
+
+    expect(allCookies).toEqual({
+      [COOKIE_KEY]: COOKIE_VALUE,
+      [COOKIE_KEY2]: COOKIE_VALUE2,
+    });
+  });
+
+  test("remove로 쿠키를 삭제할수 있어야한다.", () => {
+    cookieManager.remove(COOKIE_KEY);
+    expect(cookieManager.get(COOKIE_KEY)).toBeUndefined();
+  });
+
+  test("addChangeListener로 쿠키 변경 리스너를 추가할 수 있어야 한다.", () => {
+    cookieManager.set(COOKIE_KEY, COOKIE_VALUE);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  test("removeChangeListener로 쿠키 변경 리스너를 제거할 수 있어야 한다.", () => {
+    cookieManager.removeChangeListener(callback);
+    cookieManager.set(COOKIE_KEY2, COOKIE_VALUE2);
+    expect(callback).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/module/cookie/config/index.ts
+++ b/src/module/cookie/config/index.ts
@@ -1,0 +1,1 @@
+export { refreshTokenDefaultOptions } from "./options";

--- a/src/module/cookie/config/options.ts
+++ b/src/module/cookie/config/options.ts
@@ -1,0 +1,10 @@
+import { TIMES } from "../constant";
+
+const refreshTokenDefaultOptions = {
+  path: "/",
+  maxAge: TIMES.ONE_WEEKEND,
+  sameSite: false,
+  secure: true,
+};
+
+export { refreshTokenDefaultOptions };

--- a/src/module/cookie/constant/index.ts
+++ b/src/module/cookie/constant/index.ts
@@ -1,0 +1,1 @@
+export { TIMES } from "./time";

--- a/src/module/cookie/constant/time.ts
+++ b/src/module/cookie/constant/time.ts
@@ -1,0 +1,8 @@
+const TIMES = {
+  ONE_MINUTE: 60,
+  ONE_HOURE: 60 * 60,
+  ONE_DAY: 24 * 60 * 60,
+  ONE_WEEKEND: 7 * 24 * 60 * 60,
+};
+
+export { TIMES };

--- a/src/module/cookie/implement/UniversalCookieManager.ts
+++ b/src/module/cookie/implement/UniversalCookieManager.ts
@@ -1,0 +1,44 @@
+import Cookies from "universal-cookie";
+import {
+  CookieGetOptions,
+  CookieSetOptions,
+  CookieChangeOptions,
+} from "universal-cookie/cjs/types";
+
+import CookieManager from "../interface/CookieManager";
+
+class UniversalCookieManager implements CookieManager {
+  private cookies: Cookies;
+  private defaultOptions?: CookieSetOptions;
+
+  constructor(defaultOptions?: CookieSetOptions) {
+    this.cookies = new Cookies();
+    this.defaultOptions = defaultOptions;
+  }
+
+  get(key: string, options?: CookieGetOptions): string | undefined {
+    return this.cookies.get(key, options);
+  }
+
+  getAll(options?: CookieGetOptions) {
+    return this.cookies.getAll(options);
+  }
+
+  set<T>(key: string, value: T, options?: CookieSetOptions) {
+    this.cookies.set(key, value, { ...this.defaultOptions, ...options });
+  }
+
+  remove(key: string, options?: CookieSetOptions) {
+    this.cookies.remove(key, { ...this.defaultOptions, ...options });
+  }
+
+  addChangeListener(callback: (options: CookieChangeOptions) => void): void {
+    this.cookies.addChangeListener(callback);
+  }
+
+  removeChangeListener(callback: (options: CookieChangeOptions) => void): void {
+    this.cookies.removeChangeListener(callback);
+  }
+}
+
+export default UniversalCookieManager;

--- a/src/module/cookie/index.ts
+++ b/src/module/cookie/index.ts
@@ -1,0 +1,6 @@
+import { refreshTokenDefaultOptions } from "./config";
+import UniversalCookieManager from "./implement/UniversalCookieManager";
+
+const cookieManager = new UniversalCookieManager(refreshTokenDefaultOptions);
+
+export { cookieManager };

--- a/src/module/cookie/interface/CookieManager.ts
+++ b/src/module/cookie/interface/CookieManager.ts
@@ -1,0 +1,11 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+interface CookieManager {
+  get: (key: string, options?: any) => string | undefined;
+  getAll: (options?: any) => { [name: string]: any };
+  set: <T>(key: string, value: T, options?: any) => void;
+  remove: (key: string, options?: any) => void;
+  addChangeListener(callback: any): void;
+  removeChangeListener(callback: any): void;
+}
+
+export default CookieManager;


### PR DESCRIPTION
# 체크리스트

- [x] 작업 내용이 스프린드 보드에서 할당한 내용과 동일합니다.
- [x] 커밋 메시지가 가이드라인을 따릅니다.
- [x] 코딩 컨벤션 가이드라인을 준수하였습니다.
- [x] 변경 사항에 대한 테스트가 추가되었습니다.
- [x] 기존의 모든 자동화된 테스트를 통과합니다.

# 설명

UniversalCookieManager 모듈을 사용해서 쿠키를 조작할수있습니다.
- get : 쿠키 가져옴
- getAll : 모든 쿠키를 가져옴
- set : 쿠키를 저장
- remove : 쿠키를 삭제
- addChangeListener : 쿠키 조작 메서드가 실행되면 callback 매개변수가 실행됨
- addChangeListener : callback 매개변수 삭제

UniversalCookieManager 모듈은 universal-cookie의 Cookie 객체를 사용합니다.
react-cookie를 사용하는 이유는 useCookie라는 훅을 사용하기 위함인데 모듈에서 훅을 사용할수 없기때문에
universal-cookie을 사용했습니다.

react-cookie에서도 Cookie 객체를 사용할수 있습니다. 그 이유는 react-cookie안에 universal-cookie가 포함되어있기때문입니다.
하지만 Cookie 객체만 사용하면 되기때문에 universal-cookie를 사용했습니다.

# 테스트 방법

1. set으로 쿠키 설정 할수 있어야한다.
2. get으로 쿠키를 가져올수 있어야한다.
3. getAll으로 모든 쿠키를 가져올수 있어야한다.
4. remove로 쿠키를 삭제할수 있어야한다.
5. addChangeListener로 쿠키 변경 리스너를 추가할 수 있어야 한다.
6. removeChangeListener로 쿠키 변경 리스너를 제거할 수 있어야 한다.

