### PR TITLE
[#53] feat : signup api save AT&RT tokens

### DIFF
--- a/src/hooks/__test__/useSignUp.test.tsx
+++ b/src/hooks/__test__/useSignUp.test.tsx
@@ -57,11 +57,15 @@ describe("useSignUp", () => {
     });
 
     await waitFor(() => {
-      const { message } = queryClient.getQueryData([QUERY_KEY.user]) as {
+      const { message, token } = queryClient.getQueryData([QUERY_KEY.user]) as {
         message: string;
+        token: object;
       };
 
       expect(message).toEqual("OK");
+      expect(token).toEqual({
+        accessToken: "Test access token",
+      });
     });
   });
 

--- a/src/hooks/useSignUp.ts
+++ b/src/hooks/useSignUp.ts
@@ -2,8 +2,20 @@ import { useQueryClient, useMutation } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 
 import { QUERY_KEY } from "@/constants/queryKeys";
+import { cookieManager } from "@/module/cookie";
+import { KEY } from "@/module/cookie/constant";
 import { httpService } from "@/module/http";
 import { State } from "@/store/signupStore";
+
+type DataType = {
+  item: string;
+  target: string;
+  message: string;
+  token: {
+    accessToken: string;
+    refreshToken?: string;
+  };
+};
 
 export function useSignUp(baseURL: string) {
   const navigate = useNavigate();
@@ -11,9 +23,15 @@ export function useSignUp(baseURL: string) {
   const queryClient = useQueryClient();
 
   const signUpMutation = useMutation(
-    (userData: State) => httpService.post(baseURL, userData),
+    (userData: State): Promise<DataType> => httpService.post(baseURL, userData),
     {
-      onSuccess: data => {
+      onSuccess: (data: DataType) => {
+        if (data.message === "OK") {
+          const { refreshToken, ...restToken } = data.token;
+          data = { ...data, token: restToken };
+          cookieManager.set(KEY.JWT_REFRESH_TOKEN, refreshToken);
+        }
+
         queryClient.setQueryData([QUERY_KEY.user], data);
         navigate("/auth/signup/complete"); // 추후 수정 예정
       },

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -55,9 +55,15 @@ export const handlers = [
         item: email,
         target: "email",
         message: "OK",
+        token: {
+          accessToken: "Test access token",
+          refreshToken: "Test refresh token",
+        },
       };
     } else {
-      responseData = { message: "FORBIDDEN" };
+      responseData = {
+        message: "FORBIDDEN",
+      };
     }
 
     return res(ctx.status(200), ctx.json(responseData));

--- a/src/module/cookie/constant/index.ts
+++ b/src/module/cookie/constant/index.ts
@@ -1,1 +1,2 @@
 export { TIMES } from "./time";
+export { KEY } from "./key";

--- a/src/module/cookie/constant/key.ts
+++ b/src/module/cookie/constant/key.ts
@@ -1,0 +1,5 @@
+const KEY = {
+  JWT_REFRESH_TOKEN: "jwtRefreshToken",
+};
+
+export { KEY };


### PR DESCRIPTION
# 체크리스트

- [x] 작업 내용이 스프린드 보드에서 할당한 내용과 동일합니다.
- [x] 커밋 메시지가 가이드라인을 따릅니다.
- [x] 코딩 컨벤션 가이드라인을 준수하였습니다.
- [x] 변경 사항에 대한 테스트가 추가되었습니다.
- [x] 기존의 모든 자동화된 테스트를 통과합니다.

# 설명

회원가입시 액세스토큰은 queryClient에 저장
리프레쉬토큰은 쿠키에 저장

# 테스트 방법
회원가입시 mock서버에서 토큰을 내려주고 검증합니다.

