### PR TITLE
[#55] feat : token based reauthentication

### DIFF
--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -62,4 +62,16 @@ export const handlers = [
 
     return res(ctx.status(200), ctx.json(responseData));
   }),
+
+  // 액세스 토큰 인증
+  rest.post("https://api.example.com/request", (req, res, ctx) => {
+    let responseData;
+    if (req.headers.get("Authorization")?.split(" ")[1]) {
+      responseData = { message: "Token is vaild" };
+    } else {
+      responseData = { message: "Token is invaild" };
+    }
+
+    return res(ctx.status(200), ctx.json(responseData));
+  }),
 ];

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -63,10 +63,13 @@ export const handlers = [
     return res(ctx.status(200), ctx.json(responseData));
   }),
 
-  // 액세스 토큰 인증
+  // 액세스 토큰 및 리프레시토큰 인증
   rest.post("https://api.example.com/request", (req, res, ctx) => {
     let responseData;
-    if (req.headers.get("Authorization")?.split(" ")[1]) {
+    if (
+      req.headers.get("Authorization")?.split(" ")[1] &&
+      req.headers.get("Cookie")
+    ) {
       responseData = { message: "Token is vaild" };
     } else {
       responseData = { message: "Token is invaild" };

--- a/src/module/http/__test__/AxiosHttpHandler.test.ts
+++ b/src/module/http/__test__/AxiosHttpHandler.test.ts
@@ -15,4 +15,32 @@ describe("AxiosHttpHandler", () => {
       name: "John Doe",
     });
   });
+
+  test("request access token", async () => {
+    const response = await axiosHttpHandler.post(
+      `https://api.example.com/request`,
+      {},
+      {
+        token: {
+          accessToken: "123",
+        },
+      },
+    );
+
+    expect(response).toEqual({
+      message: "Token is vaild",
+    });
+  });
+
+  test("request not access token", async () => {
+    const response = await axiosHttpHandler.post(
+      `https://api.example.com/request`,
+      {},
+      { timeout: 1000 },
+    );
+
+    expect(response).toEqual({
+      message: "Token is invaild",
+    });
+  });
 });

--- a/src/module/http/__test__/AxiosHttpHandler.test.ts
+++ b/src/module/http/__test__/AxiosHttpHandler.test.ts
@@ -16,13 +16,14 @@ describe("AxiosHttpHandler", () => {
     });
   });
 
-  test("request access token", async () => {
+  test("사용자 인증이 필요한 API요청시 토큰을 삽입했을떄", async () => {
     const response = await axiosHttpHandler.post(
       `https://api.example.com/request`,
       {},
       {
         token: {
           accessToken: "123",
+          refreshToken: "456",
         },
       },
     );
@@ -32,7 +33,7 @@ describe("AxiosHttpHandler", () => {
     });
   });
 
-  test("request not access token", async () => {
+  test("사용자 인증이 필요한 API요청시 토큰을 안 넣었을떄", async () => {
     const response = await axiosHttpHandler.post(
       `https://api.example.com/request`,
       {},

--- a/src/module/http/constant/index.ts
+++ b/src/module/http/constant/index.ts
@@ -1,4 +1,4 @@
-import { RequestSubConfigMap } from "../type";
+import type { RequestSubConfigMap, RequestToken } from "../type";
 
 const jjanURL = import.meta.env.VITE_EXAMPLE_JJAN_URL;
 const kakaoURL = import.meta.env.VITE_EXAMPLE_KAKAO_URL;
@@ -10,5 +10,9 @@ const TEST_URL = "api.example.com";
 export const requestHeaderMap: RequestSubConfigMap = {
   [jjanURL]: { Authorization: `Bearer ${jjanToken}` },
   [kakaoURL]: { Authorization: `KakaoAK ${kakaoToken}` },
-  [TEST_URL]: (token: string) => ({ Authorization: `Bearer ${token}` }),
+  // 💡 추후 Cookie값을 직접 조작하지 않는 방법으로 리팩토링 예정
+  [TEST_URL]: (token: RequestToken) => ({
+    Authorization: `Bearer ${token?.accessToken}`,
+    Cookie: `refresh_token=${token?.refreshToken}`,
+  }),
 };

--- a/src/module/http/constant/index.ts
+++ b/src/module/http/constant/index.ts
@@ -5,7 +5,10 @@ const kakaoURL = import.meta.env.VITE_EXAMPLE_KAKAO_URL;
 const jjanToken = import.meta.env.VITE_EXAMPLE_JJAN_TOKEN;
 const kakaoToken = import.meta.env.VITE_EXAMPLE_KAKAO_TOKEN;
 
+const TEST_URL = "api.example.com";
+
 export const requestHeaderMap: RequestSubConfigMap = {
   [jjanURL]: { Authorization: `Bearer ${jjanToken}` },
   [kakaoURL]: { Authorization: `KakaoAK ${kakaoToken}` },
+  [TEST_URL]: (token: string) => ({ Authorization: `Bearer ${token}` }),
 };

--- a/src/module/http/implement/AxiosHttpHandler.ts
+++ b/src/module/http/implement/AxiosHttpHandler.ts
@@ -8,15 +8,13 @@ import type {
 
 import { requestHeaderMap } from "../constant";
 import HttpHandler from "../interface/HttpHandler";
-import type { RequestConfig, RequestToken } from "../type";
+import type { RequestConfig } from "../type";
 import { getRequestHeader } from "../util";
 import { extractDomain } from "../util";
 
 import { mergeObjects } from "@/utils/objects";
 
-type AxiosRequestConfigAdaptor = Partial<AxiosRequestConfig> &
-  RequestConfig &
-  RequestToken;
+type AxiosRequestConfigAdaptor = Partial<AxiosRequestConfig> & RequestConfig;
 
 class AxiosHttpHandler implements HttpHandler {
   private instance: AxiosInstance;
@@ -89,7 +87,7 @@ class AxiosHttpHandler implements HttpHandler {
       headers: getRequestHeader(
         requestHeaderMap,
         extractDomain(url),
-        config.token?.accessToken,
+        config.token,
       ),
       /**
        * params: getRequestHeader(this.domain),

--- a/src/module/http/type/index.ts
+++ b/src/module/http/type/index.ts
@@ -1,18 +1,24 @@
 type HeaderConfig =
   | Record<string, string>
-  | ((param: string) => Record<string, string>);
+  | ((param: RequestToken) => Record<string, string>);
 type RequestSubConfigMap = Record<string, HeaderConfig>;
 
 type RequestConfig = {
   params?: object;
   headers?: object;
+  token?: RequestToken;
 };
 type HttpMethod = "get" | "post" | "delete" | "put" | "patch";
 
 interface RequestToken {
-  token?: {
-    accessToken: string;
-  };
+  accessToken: string;
+  refreshToken: string;
 }
 
-export type { RequestConfig, RequestSubConfigMap, HttpMethod, RequestToken };
+export type {
+  RequestConfig,
+  RequestSubConfigMap,
+  HttpMethod,
+  RequestToken,
+  HeaderConfig,
+};

--- a/src/module/http/type/index.ts
+++ b/src/module/http/type/index.ts
@@ -1,8 +1,18 @@
-type RequestSubConfigMap = Record<string, Record<string, string>>;
+type HeaderConfig =
+  | Record<string, string>
+  | ((param: string) => Record<string, string>);
+type RequestSubConfigMap = Record<string, HeaderConfig>;
+
 type RequestConfig = {
   params?: object;
   headers?: object;
 };
 type HttpMethod = "get" | "post" | "delete" | "put" | "patch";
 
-export type { RequestConfig, RequestSubConfigMap, HttpMethod };
+interface RequestToken {
+  token?: {
+    accessToken: string;
+  };
+}
+
+export type { RequestConfig, RequestSubConfigMap, HttpMethod, RequestToken };

--- a/src/module/http/util/index.ts
+++ b/src/module/http/util/index.ts
@@ -1,13 +1,14 @@
-import type { RequestSubConfigMap } from "../type";
+import type { RequestSubConfigMap, RequestToken } from "../type";
 
 export function getRequestHeader(
   requestHeaderMap: RequestSubConfigMap,
   url: string,
-  token?: string,
+  token?: RequestToken,
 ): Record<string, string> {
   const headerConfig = requestHeaderMap[url];
   if (typeof headerConfig === "function") {
-    return headerConfig(token || "");
+    if (token) return headerConfig(token || token);
+    else return {};
   }
   return headerConfig || {};
 }

--- a/src/module/http/util/index.ts
+++ b/src/module/http/util/index.ts
@@ -3,8 +3,13 @@ import type { RequestSubConfigMap } from "../type";
 export function getRequestHeader(
   requestHeaderMap: RequestSubConfigMap,
   url: string,
+  token?: string,
 ): Record<string, string> {
-  return requestHeaderMap[url] || {};
+  const headerConfig = requestHeaderMap[url];
+  if (typeof headerConfig === "function") {
+    return headerConfig(token || "");
+  }
+  return headerConfig || {};
 }
 
 export function extractDomain(url: string): string {


### PR DESCRIPTION
# 체크리스트

- [x] 작업 내용이 스프린드 보드에서 할당한 내용과 동일합니다.
- [x] 커밋 메시지가 가이드라인을 따릅니다.
- [x] 코딩 컨벤션 가이드라인을 준수하였습니다.
- [x] 변경 사항에 대한 테스트가 추가되었습니다.
- [x] 기존의 모든 자동화된 테스트를 통과합니다.

# 설명

api요청시 config에 액세스토큰을 넣은면 자동으로 헤더에 액세스 토큰을 삽입해 요청합니다.
그리고 서버에서 Set-cookie에 httpOnly옵션과 토큰을 함께 넘겨주면 자동으로 브라우저에서 토큰을 저장 및 같은 도메인에 api요청시
헤더의 Cookie에 해당 토큰값을 자동으로 삽입한다는 점을 알게되어서 따로 리프레시 토큰은 관리하지 않아도 될것같습니다. 

# 변경 사항

getRequestHeader 함수를 매개변수로 액세스 토큰을 받게 변경했습니다.

# 테스트 방법

api 서버에 토큰을 넣고 요청시 헤더에 액세스 토큰이 있는지 여부를 검사합니다. 만약 토큰대신 다른 옵션을 넣었을떄는
토큰이 존재하지 않아야합니다. 
