### PR TITLE
[#60] feat : create text area component

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -9,6 +9,9 @@ const preview: Preview = {
         date: /Date$/,
       },
     },
+    options: {
+      resetArgsOnUnmount: false, // args 리셋 비활성화
+    },
   },
 };
 

--- a/components/textField/TextArea.css
+++ b/components/textField/TextArea.css
@@ -1,0 +1,29 @@
+.textarea-container {
+  border: 1px solid black;
+  border-radius: 22px;
+  position: relative;
+}
+
+.textarea {
+  resize: none;
+  background: none;
+  border: none;
+  width: 96%;
+  height: 85%;
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  outline: none;
+}
+
+.textarea::-webkit-scrollbar {
+  display: none;
+}
+
+.textarea-word-count {
+  position: absolute;
+  bottom: 3em;
+  right: 3em;
+  font-size: 0.2em;
+  opacity: 0.4;
+}

--- a/components/textField/TextArea.stories.tsx
+++ b/components/textField/TextArea.stories.tsx
@@ -1,0 +1,26 @@
+import { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import { TextArea } from "./TextArea";
+import { TextAreaProps } from "./types";
+
+const meta: Meta<typeof TextArea> = {
+  title: "TextArea",
+  component: TextArea,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TextArea>;
+
+export const Default: Story = (args: TextAreaProps) => {
+  return <TextArea {...args} />;
+};
+Default.args = {
+  minLength: 2,
+  maxLength: 5,
+  width: "300px",
+  height: "200px",
+  placeholder: "입력하는 장소..",
+  disabled: false,
+};

--- a/components/textField/TextArea.test.tsx
+++ b/components/textField/TextArea.test.tsx
@@ -1,0 +1,61 @@
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+import { vi } from "vitest";
+
+import { TextArea } from "./TextArea";
+
+describe("TextArea 컴포넌트", () => {
+  test("width와 height가 올바르게 적용되어야 합니다.", () => {
+    const { container } = render(<TextArea width="1000px" height="800px" />);
+    const textareaContainer = container.querySelector(".textarea-container");
+
+    expect(textareaContainer).toHaveStyle("width: 1000px");
+    expect(textareaContainer).toHaveStyle("height: 800px");
+  });
+
+  test("minLength와 maxLength가 올바르게 적용되고 span태그에 표시되어야 합니다.", async () => {
+    const { getByText, getByTestId } = render(
+      <TextArea
+        defaultValue={"5글자가넘는매우긴문장"}
+        minLength={2}
+        maxLength={5}
+        testId="textBox"
+      />,
+    );
+    const wordCount = getByText(/\/최대 5자/);
+    expect(wordCount).toHaveTextContent("5/최대 5자");
+
+    const textArea = getByTestId("textBox");
+
+    const minLength = textArea.getAttribute("minlength");
+    expect(minLength).toBe("2");
+
+    const maxLength = textArea.getAttribute("maxLength");
+    expect(maxLength).toBe("5");
+
+    const { textContent } = textArea;
+    expect(textContent?.length).toBe(5);
+  });
+
+  test("placeholder가 올바르게 적용되어야 합니다.", () => {
+    const placeholderText = "입력하는 장소..";
+    const { getByTestId } = render(
+      <TextArea placeholder={placeholderText} testId="textBox" />,
+    );
+    const textarea = getByTestId("textBox");
+
+    expect(textarea).toHaveAttribute("placeholder", placeholderText);
+  });
+
+  test("disabled 옵션이 설정되면 클릭이 안되어야 합니다.", () => {
+    const handleClick = vi.fn();
+    const { getByTestId } = render(
+      <TextArea disabled testId="textBox" onClick={handleClick} />,
+    );
+    const textarea = getByTestId("textBox");
+
+    fireEvent.click(textarea);
+
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+});

--- a/components/textField/TextArea.tsx
+++ b/components/textField/TextArea.tsx
@@ -1,0 +1,53 @@
+import React, { forwardRef, ForwardedRef, useState, ChangeEvent } from "react";
+
+import type { TextAreaProps } from "./types";
+import "./TextArea.css";
+
+const TextArea = (
+  props: TextAreaProps,
+  ref: ForwardedRef<HTMLTextAreaElement>,
+) => {
+  const {
+    defaultValue,
+    width = "200px",
+    height = "150px",
+    minLength,
+    maxLength = 60,
+    testId,
+    ...otherProps
+  } = props;
+
+  const [value, setValue] = useState(
+    defaultValue ? String(defaultValue).slice(0, maxLength) : "",
+  );
+
+  const handleInputChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    const inputText = event.target.value;
+    if (inputText.length > maxLength) {
+      event.preventDefault();
+      return;
+    }
+    setValue(inputText);
+  };
+
+  return (
+    <div className="textarea-container" style={{ width, height }}>
+      <textarea
+        {...otherProps}
+        ref={ref}
+        className="textarea"
+        value={value}
+        onChange={handleInputChange}
+        minLength={minLength}
+        maxLength={maxLength}
+        data-testid={testId}
+      />
+      <small className="textarea-word-count">
+        {String(value).length}/최대 {maxLength}자
+      </small>
+    </div>
+  );
+};
+
+const _TextArea = forwardRef(TextArea);
+export { _TextArea as TextArea };

--- a/components/textField/index.ts
+++ b/components/textField/index.ts
@@ -1,0 +1,1 @@
+export { TextArea } from "./TextArea";

--- a/components/textField/types.ts
+++ b/components/textField/types.ts
@@ -1,0 +1,13 @@
+import { TextareaHTMLAttributes } from "react";
+
+import { BaseTest } from "../types/base";
+
+type TextAreaBaseProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+type TextAreaProps = TextAreaBaseProps &
+  BaseTest & {
+    width?: string;
+    height?: string;
+  };
+
+export { TextAreaProps };


### PR DESCRIPTION
# 체크리스트

- [x] 작업 내용이 스프린드 보드에서 할당한 내용과 동일합니다.
- [x] 커밋 메시지가 가이드라인을 따릅니다.
- [x] 코딩 컨벤션 가이드라인을 준수하였습니다.
- [x] 변경 사항에 대한 테스트가 추가되었습니다.
- [x] 기존의 모든 자동화된 테스트를 통과합니다.

# 설명

textField/ 아래에 TextArea 컴포넌트를 구현했습니다. 후에 TextField도 추가될 가능성이 있습니다.

# 변경 사항

resetArgsOnUnmount: false 옵션은 스토리북의 args를 control 패널에서 조작후 unmount시에도 유지해줍니다.

# 테스트 방법

1. width와 height가 올바르게 적용되어야 합니다
2. minLength와 maxLength가 올바르게 적용되고 span태그에 표시되어야 합니다.
3. placeholder가 올바르게 적용되어야 합니다.
4. disabled 옵션이 설정되면 클릭이 안되어야 합니다.
