### PR TITLE
[#89] feat : create useSkate hook

### DIFF
--- a/src/hooks/__test__/useSkate.test.tsx
+++ b/src/hooks/__test__/useSkate.test.tsx
@@ -1,0 +1,67 @@
+import { render, fireEvent } from "@testing-library/react";
+
+import useSkate from "../useSkate";
+
+const COMPONENT_NAMES = {
+  FIRST: "첫 번째",
+  SECOND: "두 번째",
+  THIRD: "세 번째",
+};
+
+const TestComponent = () => {
+  const { Skate, setSkateStep } = useSkate(Object.values(COMPONENT_NAMES));
+
+  return (
+    <div>
+      <button
+        data-testid="1 버튼"
+        onClick={() => setSkateStep(COMPONENT_NAMES.FIRST)}
+      />
+      <button
+        data-testid="2 버튼"
+        onClick={() => setSkateStep(COMPONENT_NAMES.SECOND)}
+      />
+      <button
+        data-testid="3 버튼"
+        onClick={() => setSkateStep(COMPONENT_NAMES.THIRD)}
+      />
+
+      <Skate>
+        <Skate.Step name={COMPONENT_NAMES.FIRST}>
+          <p>첫 번째 컴포넌트입니다.</p>
+        </Skate.Step>
+        <Skate.Step name={COMPONENT_NAMES.SECOND}>
+          <p>두 번째 컴포넌트입니다.</p>
+        </Skate.Step>
+        <Skate.Step name={COMPONENT_NAMES.THIRD}>
+          <p>세 번째 컴포넌트입니다.</p>
+        </Skate.Step>
+      </Skate>
+    </div>
+  );
+};
+
+describe("useSkate 테스트", () => {
+  it("첫 마운트 때 '첫 번째 컴포넌트입니다.' 텍스트가 있는지 확인", () => {
+    const { getByText } = render(<TestComponent />);
+    expect(getByText("첫 번째 컴포넌트입니다.")).toBeInTheDocument();
+  });
+
+  it("1 버튼을 클릭하면 '첫 번째 컴포넌트입니다.' 텍스트가 보이는지 확인", () => {
+    const { getByText, getByTestId } = render(<TestComponent />);
+    fireEvent.click(getByTestId("1 버튼"));
+    expect(getByText("첫 번째 컴포넌트입니다.")).toBeInTheDocument();
+  });
+
+  it("2 버튼을 클릭하면 '두 번째 컴포넌트입니다.' 텍스트가 보이는지 확인", () => {
+    const { getByText, getByTestId } = render(<TestComponent />);
+    fireEvent.click(getByTestId("2 버튼"));
+    expect(getByText("두 번째 컴포넌트입니다.")).toBeInTheDocument();
+  });
+
+  it("3 버튼을 클릭하면 '세 번째 컴포넌트입니다.' 텍스트가 보이는지 확인", () => {
+    const { getByText, getByTestId } = render(<TestComponent />);
+    fireEvent.click(getByTestId("3 버튼"));
+    expect(getByText("세 번째 컴포넌트입니다.")).toBeInTheDocument();
+  });
+});

--- a/src/hooks/useSkate.tsx
+++ b/src/hooks/useSkate.tsx
@@ -1,0 +1,40 @@
+import { useState, ReactNode } from "react";
+
+type SkateProps = {
+  name: string;
+  children: ReactNode;
+};
+
+type SkateComponent = ({ name, children }: SkateProps) => JSX.Element;
+
+type SkateBaseProps = { children: ReactNode[] };
+
+type SkateBaseComponent = ({ children }: SkateBaseProps) => JSX.Element;
+
+type SkateType = SkateBaseComponent & {
+  Step: SkateComponent;
+};
+
+type UseSkateReturn = {
+  Skate: SkateType;
+  setSkateStep: (stepName: string) => void;
+};
+
+function useSkate(stepNames: string[]): UseSkateReturn {
+  type stepNamesUnion = (typeof stepNames)[number];
+  const [skateStep, setSkateStep] = useState<stepNamesUnion>(stepNames[0]);
+
+  const Step: SkateComponent = ({ name, children }) => {
+    return <>{skateStep === name && <>{children}</>}</>;
+  };
+
+  const SkateBase: SkateBaseComponent = ({ children }) => {
+    return <>{children}</>;
+  };
+
+  const Skate = Object.assign(SkateBase, { Step });
+
+  return { Skate, setSkateStep };
+}
+
+export default useSkate;

--- a/src/lab/SkateTestComponents.tsx
+++ b/src/lab/SkateTestComponents.tsx
@@ -1,0 +1,75 @@
+import { ProgressBar } from "@/components/progressbar";
+import useProgressBar from "@/components/progressbar/useProgressBar";
+import useSkate from "@/hooks/useSkate";
+
+const COMPONENT_NAMES = {
+  FIRST: "첫 번째",
+  SECOND: "두 번째",
+  THIRD: "세 번째",
+};
+
+const SkateTestComponents = () => {
+  const componentsLen = Object.keys(COMPONENT_NAMES).length;
+  const { step, setGaugeUp, setGaugeDown } = useProgressBar(1, componentsLen);
+
+  const { Skate, setSkateStep } = useSkate(Object.values(COMPONENT_NAMES));
+
+  const onProgressBar = (nextStep: number) => {
+    const diff = Math.abs(nextStep - step);
+    if (nextStep > step) {
+      for (let i = 0; i < diff; i++) {
+        setGaugeUp();
+      }
+    }
+
+    if (nextStep < step) {
+      for (let i = 0; i < diff; i++) {
+        setGaugeDown();
+      }
+    }
+  };
+
+  return (
+    <div>
+      <button
+        onClick={() => {
+          setSkateStep(COMPONENT_NAMES.FIRST);
+          onProgressBar(1);
+        }}
+      >
+        첫 번째 컴포넌트 보기
+      </button>
+      <button
+        onClick={() => {
+          setSkateStep(COMPONENT_NAMES.SECOND);
+          onProgressBar(2);
+        }}
+      >
+        두 번째 컴포넌트 보기
+      </button>
+      <button
+        onClick={() => {
+          setSkateStep(COMPONENT_NAMES.THIRD);
+          onProgressBar(3);
+        }}
+      >
+        세 번째 컴포넌트 보기
+      </button>
+      <hr></hr>
+      <ProgressBar curStep={step} totalSteps={componentsLen} />
+      <Skate>
+        <Skate.Step name={COMPONENT_NAMES.FIRST}>
+          <p>첫 번째 컴포넌트입니다.</p>
+        </Skate.Step>
+        <Skate.Step name={COMPONENT_NAMES.SECOND}>
+          <p>두 번째 컴포넌트입니다.</p>
+        </Skate.Step>
+        <Skate.Step name={COMPONENT_NAMES.THIRD}>
+          <p>세 번째 컴포넌트입니다.</p>
+        </Skate.Step>
+      </Skate>
+    </div>
+  );
+};
+
+export default SkateTestComponents;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -7,7 +7,6 @@ import QueryProvider from "./queryProvider";
 import SvgLoadingSplash from "@/assets/LoadingSplash.svg";
 import { SignupProvider } from "@/store/signupStore";
 
-
 // const 로그인후불러올컴포넌트 = React.lazy(
 //   () => import("./pages/로그인후불러올컴포넌트"),
 // );


### PR DESCRIPTION
# 체크리스트

- [x] 작업 내용이 스프린드 보드에서 할당한 내용과 동일합니다.
- [x] 커밋 메시지가 가이드라인을 따릅니다.
- [x] 코딩 컨벤션 가이드라인을 준수하였습니다.
- [x] 변경 사항에 대한 테스트가 추가되었습니다.
- [x] 기존의 모든 자동화된 테스트를 통과합니다.

# 설명

useFunnel과 다르게 useSkate는 각각의 컴포넌트를 순차적으로 이동하는것이 아닌
특정 index에 바로 이동을합니다. useFunnel에 그 기능을 추가할수도 있지만
좀더 목적성을 띄는것이 좋다고 생각이 들어 구현했습니다.

JJAN의 탐색페이지에서 사용을 할때는 SkateTestComponents와 같이 사용하는 예시를
만들어봤습니다.

# 테스트 방법

각각의 컴포넌트에 해당하는 버튼을 눌렀을때 동적으로 컴포넌트가 렌더링되어야합니다.
