### PR TITLE
[#119] feat : Add cluster component

### DIFF
--- a/src/components/cluster/Cluster.styles.tsx
+++ b/src/components/cluster/Cluster.styles.tsx
@@ -1,0 +1,7 @@
+import styled from "@emotion/styled";
+
+export const Container = styled.div<{ gap?: string }>`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${({ gap }) => (gap ? gap : undefined)};
+`;

--- a/src/components/cluster/Cluster.tsx
+++ b/src/components/cluster/Cluster.tsx
@@ -1,0 +1,10 @@
+import * as S from "./Cluster.styles";
+import { ClusterProps } from "./types";
+
+const Cluster = (props: ClusterProps) => {
+  const { gap, children } = props;
+
+  return <S.Container gap={gap}>{children}</S.Container>;
+};
+
+export { Cluster };

--- a/src/components/cluster/index.ts
+++ b/src/components/cluster/index.ts
@@ -1,0 +1,2 @@
+export * from "./Cluster";
+export * from "./types";

--- a/src/components/cluster/types.ts
+++ b/src/components/cluster/types.ts
@@ -1,0 +1,8 @@
+import { ReactNode } from "react";
+
+type ClusterProps = {
+  gap?: string;
+  children: ReactNode;
+};
+
+export type { ClusterProps };


### PR DESCRIPTION
# 체크리스트

- [X] 작업 내용이 스프린드 보드에서 할당한 내용과 동일합니다.
- [X] 커밋 메시지가 가이드라인을 따릅니다.
- [X] 코딩 컨벤션 가이드라인을 준수하였습니다.
- [ ] 변경 사항에 대한 테스트가 추가되었습니다.
- [X] 기존의 모든 자동화된 테스트를 통과합니다.

# 설명

`flex-wrap : wrap` 속성을 적용해 너비에 따른 css 표현을 위해 재사용 가능한 컴포넌트로 분리한 `Cluster` 컴포넌트를 추가합니다.

# 변경 사항

- Cluster 컴포넌트 구현

# 관련 이슈

#119 
