### PR TITLE
[#120] feat : Add formtextarea child component and edit upload logic of form component

### DIFF
--- a/src/components/form/Form.test.tsx
+++ b/src/components/form/Form.test.tsx
@@ -60,7 +60,7 @@ const exampleLoginSchema = z.object({
 });
 
 const exampleUploaderSchema = z.object({
-  profile: z.instanceof(FileList).refine(
+  profile: z.instanceof(Array<File>).refine(
     files => {
       return Array.from(files).every(file =>
         ACCEPTED_IMAGE_TYPES.includes(file.type),
@@ -233,6 +233,7 @@ describe("Form Component", () => {
           <Form.ImageUploader
             name="profile"
             render={(props: RenderProps) => ExampleRenderUI(props)}
+            mode="single"
             testId="imageuploder"
           />
           <button type="submit">click me</button>
@@ -262,6 +263,7 @@ describe("Form Component", () => {
           <Form.ImageUploader
             name="profile"
             render={(props: RenderProps) => ExampleRenderUI(props)}
+            mode="single"
             testId="imageuploder"
           />
           <button type="submit">click me</button>

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -2,6 +2,7 @@ import { useForm, FormProvider } from "react-hook-form";
 import type { FieldValues } from "react-hook-form";
 
 import { FormInput as Input } from "./formInput";
+import { FormTextarea as Textarea } from "./formTextarea";
 import { ImageUploader } from "./imageUploader";
 import type { FormProps } from "./types";
 
@@ -27,6 +28,6 @@ const FormBase = <TFieldValues extends FieldValues>({
   );
 };
 
-const Form = Object.assign(FormBase, { Input, ImageUploader });
+const Form = Object.assign(FormBase, { Input, Textarea, ImageUploader });
 
 export { Form };

--- a/src/components/form/formTextarea/FormTextarea.tsx
+++ b/src/components/form/formTextarea/FormTextarea.tsx
@@ -1,0 +1,36 @@
+import { useFormContext } from "react-hook-form";
+
+import { FormTextAreaProps } from "./types";
+
+import { Stack } from "@/components/stack";
+import { TextArea } from "@/components/textField";
+import { Typo } from "@/components/typo";
+
+const FormTextarea = (props: FormTextAreaProps) => {
+  const { width, height, name, ...restProps } = props;
+  const {
+    register,
+    formState: { errors },
+    getValues,
+  } = useFormContext();
+
+  return (
+    <Stack space="space02">
+      <TextArea
+        id={name}
+        width={width}
+        height={height}
+        defaultValue={getValues(name)}
+        {...restProps}
+        {...register(name)}
+      />
+      {errors[name] && (
+        <Typo appearance="body3" as="span" role="alert" color="violet400">
+          {errors[name]?.message?.toString()}
+        </Typo>
+      )}
+    </Stack>
+  );
+};
+
+export { FormTextarea };

--- a/src/components/form/formTextarea/index.tsx
+++ b/src/components/form/formTextarea/index.tsx
@@ -1,0 +1,1 @@
+export * from "./FormTextarea";

--- a/src/components/form/formTextarea/types.ts
+++ b/src/components/form/formTextarea/types.ts
@@ -1,0 +1,10 @@
+import { TextAreaProps } from "@/components/textField";
+
+type FormTextAreaOmitProps = "name";
+
+type FormTextAreaProps = { name: string } & Omit<
+  TextAreaProps,
+  FormTextAreaOmitProps
+>;
+
+export type { FormTextAreaProps };

--- a/src/components/form/imageUploader/types.ts
+++ b/src/components/form/imageUploader/types.ts
@@ -3,8 +3,10 @@ import { InputHTMLAttributes, ReactNode } from "react";
 import { BaseTest } from "../../types/base";
 
 type RenderProps = {
-  files: FileList;
+  files: File[];
   handleClick: () => void;
+  handleDeleteByIndex: (target: number) => void;
+  handleDeleteAll: () => void;
 };
 
 type ImageUploaderProps = Omit<InputHTMLAttributes<HTMLInputElement>, "name"> &
@@ -17,6 +19,7 @@ type ImageUploaderProps = Omit<InputHTMLAttributes<HTMLInputElement>, "name"> &
      * render function
      */
     render: (props: RenderProps) => ReactNode;
+    mode?: "single" | "multiple";
     accepts?: string;
   };
 


### PR DESCRIPTION
# 체크리스트

- [X] 작업 내용이 스프린드 보드에서 할당한 내용과 동일합니다.
- [X] 커밋 메시지가 가이드라인을 따릅니다.
- [X] 코딩 컨벤션 가이드라인을 준수하였습니다.
- [ ] 변경 사항에 대한 테스트가 추가되었습니다.
- [ ] 기존의 모든 자동화된 테스트를 통과합니다.

# 설명

textarea 요소처럼 긴 문장에 대해서 입력 가능 및 유효성 검사를 수행할 수 있는 `FormTextarea` 컴포넌트를 `Form` 컴포넌트의 자식 컴포넌트로 추가합니다. 또한 기존 `ImageUploader` 컴포넌트의 이미지 업로드 방식을 수정합니다.

# 변경 사항

- FormTextarea 컴포넌트 추가
- ImageUploader 컴포넌트 업로드 파일 내부 상태를 통한 관리 방식으로 변경

# 관련 이슈

#120
