### PR TITLE
[#133] feat : home party explore api apply

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "axios": "^1.4.0",
         "embla-carousel-autoplay": "^8.0.0-rc10",
         "embla-carousel-react": "^8.0.0-rc10",
-        "jjan-icon": "^0.0.5-2023-08-17",
+        "jjan-icon": "^0.0.6-2023-08-24",
         "proj4": "^2.9.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -12999,9 +12999,9 @@
       }
     },
     "node_modules/jjan-icon": {
-      "version": "0.0.5-2023-08-17",
-      "resolved": "https://registry.npmjs.org/jjan-icon/-/jjan-icon-0.0.5-2023-08-17.tgz",
-      "integrity": "sha512-rFEZ6WjsKDN/h39/h4WAGCL3wqQOJOS9YRyVI8ioSnk6TCbQNZQcYIA1ENAGy8QaRjKwpobQNdP2FcEEcMOUhA=="
+      "version": "0.0.6-2023-08-24",
+      "resolved": "https://registry.npmjs.org/jjan-icon/-/jjan-icon-0.0.6-2023-08-24.tgz",
+      "integrity": "sha512-GB3TlMr0S0LM0RGfcWyB3g8M/FUCc+y8BHbgEWf+CRp2TRVqC0/VEJ793A+othhh99m36ocu6BEDEYqqqrsGKQ=="
     },
     "node_modules/js-levenshtein": {
       "version": "1.1.6",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "axios": "^1.4.0",
     "embla-carousel-autoplay": "^8.0.0-rc10",
     "embla-carousel-react": "^8.0.0-rc10",
-    "jjan-icon": "^0.0.5-2023-08-17",
+    "jjan-icon": "^0.0.6-2023-08-24",
     "proj4": "^2.9.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/api/jjan/partyController.ts
+++ b/src/api/jjan/partyController.ts
@@ -1,0 +1,22 @@
+import { partyRoutes } from "@/routes";
+
+import { Response } from "../types";
+
+import { JJAN_URL } from "./domain";
+import { PartyInfo } from "./types";
+
+import { httpService } from "@/module/http";
+import { serverStateManager } from "@/module/serverState";
+
+export const useFetchAllParty = () =>
+  serverStateManager.fetch<Response<PartyInfo[]>>({
+    url: `${JJAN_URL}${partyRoutes.getAllParty}`,
+  });
+
+export const fetchMyParty = () =>
+  httpService.get<Response<PartyInfo[]>>(
+    `${JJAN_URL}${partyRoutes.getMyParty}`,
+    {
+      withCredentials: true,
+    },
+  );

--- a/src/api/jjan/types.ts
+++ b/src/api/jjan/types.ts
@@ -12,3 +12,16 @@ export type SigninData = {
   email: string;
   password: string;
 };
+
+type PartyJoinUser = {
+  id: number;
+  profile: string | "blank";
+};
+
+export type PartyInfo = {
+  id: number;
+  joinUser: PartyJoinUser[];
+  partyDate: string;
+  thumbnail: string;
+  title: string;
+};

--- a/src/api/jjan/userController.ts
+++ b/src/api/jjan/userController.ts
@@ -1,7 +1,9 @@
 import { userRoutes } from "@/routes";
 
 import { JJAN_URL } from "./domain";
+import { AuthResponseData } from "./types";
 
+import { httpService } from "@/module/http";
 import { serverStateManager } from "@/module/serverState";
 
 export const useUpdateAvatar = () =>
@@ -33,4 +35,9 @@ export const useDeleteUserUserEmail = (userEmail: string) =>
         userEmail,
       },
     },
+  });
+
+export const fetchUserInfo = () =>
+  httpService.get<AuthResponseData>(`${JJAN_URL}${userRoutes.userInfo}`, {
+    withCredentials: true,
   });

--- a/src/components/avatar/Avatar.css
+++ b/src/components/avatar/Avatar.css
@@ -2,3 +2,7 @@
   pointer-events: none;
   filter: grayscale(100%);
 }
+
+.img-circle {
+  border-radius: 50%;
+}

--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -10,17 +10,20 @@ const Avatar = (props: AvatarProps, ref: ForwardedRef<HTMLImageElement>) => {
     isDisabled,
     width = "50px",
     height = "50px",
+    isCircle = false,
     src,
     testId,
     ...otherProps
   } = props;
 
-  const avatarClassName = isDisabled ? "img-disabled" : "";
+  const avatarDisabled = isDisabled ? "img-disabled" : "";
+
+  const avatarCircle = isCircle ? "img-circle" : "";
 
   return (
     <img
       {...otherProps}
-      className={avatarClassName}
+      className={`${avatarDisabled} ${avatarCircle}`}
       alt={alt}
       width={width}
       height={height}

--- a/src/components/avatar/types.ts
+++ b/src/components/avatar/types.ts
@@ -7,6 +7,7 @@ type ImageBaseProps = ImgHTMLAttributes<HTMLImageElement>;
 type AvatarProps = ImageBaseProps &
   BaseTest & {
     isDisabled?: boolean;
+    isCircle?: boolean;
   };
 
-export { AvatarProps };
+export type { AvatarProps };

--- a/src/pages/components/partyCard/PartyCard.tsx
+++ b/src/pages/components/partyCard/PartyCard.tsx
@@ -1,5 +1,5 @@
 import * as S from "./PartyCard.styles";
-import { OverlayedAvatarProps } from "./types";
+import { OverlayedAvatarProps, PartyCardProps } from "./types";
 
 import { Avatar } from "@/components/avatar";
 import { Box } from "@/components/box";
@@ -11,7 +11,18 @@ import { Typo } from "@/components/typo";
 const OverlayedAvatar = ({ overlay, ...avatarProps }: OverlayedAvatarProps) => {
   return (
     <S.OverlayContainer>
-      <Avatar {...avatarProps} style={{ borderRadius: "50%" }} />
+      {avatarProps.src === "blank" ? (
+        <Box
+          width="39px"
+          height="39px"
+          backgroundColor="gray800"
+          borderRadius="50%"
+          overflow="hidden"
+        />
+      ) : (
+        <Avatar {...avatarProps} style={{ borderRadius: "50%" }} />
+      )}
+
       {overlay && <S.OverlayText>{overlay}</S.OverlayText>}
     </S.OverlayContainer>
   );
@@ -39,10 +50,10 @@ const CardContributorsAvatar = ({ avatars }: { avatars: string[] }) => {
 };
 
 const CardInfo = ({
+  title,
+  date,
   contributorsAvatars,
-}: {
-  contributorsAvatars: string[];
-}) => {
+}: Pick<PartyCardProps, "title" | "date" | "contributorsAvatars">) => {
   return (
     <Stack>
       <Flex flexDirection="column">
@@ -51,10 +62,10 @@ const CardInfo = ({
           color="violet100"
           style={{ fontWeight: "bold" }}
         >
-          회기 꽃술 6인팟!!
+          {title}
         </Typo>
         <Typo appearance="body3" color="gray700" style={{ fontWeight: "bold" }}>
-          2023/6/29
+          {date}
         </Typo>
         <Spacing direction="vertical" size="20px" />
         <CardContributorsAvatar avatars={contributorsAvatars} />
@@ -63,10 +74,24 @@ const CardInfo = ({
   );
 };
 
-const CardImage = ({ partyImage }: { partyImage: string }) => {
+const CardImage = ({
+  partyImage,
+  dDay,
+}: Pick<PartyCardProps, "partyImage" | "dDay">) => {
   return (
     <Box width="110px" height="110px" style={{ position: "relative" }}>
-      <img src={partyImage} width="110px" height="110px" />
+      {partyImage === "black" ? (
+        <Box
+          width="110px"
+          height="110px"
+          backgroundColor="gray800"
+          borderRadius="50%"
+          overflow="hidden"
+        />
+      ) : (
+        <Avatar width="110px" height="110px" src={partyImage} />
+      )}
+
       <Box
         width="41px"
         height="18px"
@@ -74,23 +99,32 @@ const CardImage = ({ partyImage }: { partyImage: string }) => {
         style={{
           position: "absolute",
           top: "0",
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
         }}
-      />
+      >
+        <Typo appearance="info1">{`D-${dDay}`}</Typo>
+      </Box>
     </Box>
   );
 };
 
 const PartyCard = ({
   partyImage,
+  title,
+  date,
+  dDay,
   contributorsAvatars,
-}: {
-  partyImage: string;
-  contributorsAvatars: string[];
-}) => {
+}: PartyCardProps) => {
   return (
     <Flex gap="18px">
-      <CardImage partyImage={partyImage} />
-      <CardInfo contributorsAvatars={contributorsAvatars} />
+      <CardImage dDay={dDay} partyImage={partyImage} />
+      <CardInfo
+        title={title}
+        date={date}
+        contributorsAvatars={contributorsAvatars}
+      />
     </Flex>
   );
 };

--- a/src/pages/components/partyCard/types.ts
+++ b/src/pages/components/partyCard/types.ts
@@ -6,4 +6,12 @@ interface OverlayedAvatarProps {
   style?: React.CSSProperties;
 }
 
-export type { OverlayedAvatarProps };
+interface PartyCardProps {
+  partyImage: string;
+  title: string;
+  date: string;
+  dDay: number;
+  contributorsAvatars: string[];
+}
+
+export type { OverlayedAvatarProps, PartyCardProps };

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,106 +1,205 @@
-import { IconAlertEmpty, IconJjanLogo, IconLocationPlus } from "jjan-icon";
+import {
+  IconAlertEmpty,
+  IconJjanLogo,
+  IconLocationPlus,
+  IconRightArrow,
+  IconMascot1,
+  IconMascot2,
+  IconMascot3,
+  IconMascot4,
+} from "jjan-icon";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 import { NAV_ITEMS } from "./constants";
 
+import { AuthResponseData } from "@/api/jjan/types";
+import { fetchUserInfo } from "@/api/jjan/userController";
 import { Avatar } from "@/components/avatar";
 import { BottomNav } from "@/components/bottomNav";
 import { Box } from "@/components/box";
+import { Button } from "@/components/button";
 import { Flex } from "@/components/flex";
 import { Header } from "@/components/header";
+import { Spacing } from "@/components/spacing";
 import { Stack } from "@/components/stack";
 import { Typo } from "@/components/typo";
 
-const Cards = () => (
-  <Stack space="space03">
-    <Flex gap="12px">
-      <Flex.Item flex="2 1 0">
-        <Box
-          padding="16px"
-          backgroundColor="violet100"
-          borderRadius="15px"
-          height="26dvh"
-        >
-          <Stack>
-            <Typo appearance="body1" color="white">
-              오늘은 어떤 모임이
-            </Typo>
-            <Typo appearance="body1" color="white">
-              있을까요?
-            </Typo>
-          </Stack>
-        </Box>
-      </Flex.Item>
-      <Flex.Item flex="1.6 1 0">
-        <Box
-          padding="16px"
-          backgroundColor="green175"
-          borderRadius="15px"
-          height="26dvh"
-        >
-          <Typo appearance="body1">모임 만들기</Typo>
-        </Box>
-      </Flex.Item>
-    </Flex>
-    <Flex gap="12px">
-      <Flex.Item flex="1.6 1 0">
-        <Box
-          padding="16px"
-          backgroundColor="green175"
-          borderRadius="15px"
-          height="26dvh"
-        >
-          <Typo appearance="body1">나의 모임</Typo>
-        </Box>
-      </Flex.Item>
-      <Flex.Item flex="2 1 0">
-        <Box
-          padding="16px"
-          backgroundColor="violet100"
-          borderRadius="15px"
-          height="26dvh"
-        >
-          <Stack>
-            <Typo appearance="body1" color="white">
-              관심있는 모임
-            </Typo>
-            <Typo appearance="body1" color="white">
-              모아보기
-            </Typo>
-          </Stack>
-        </Box>
-      </Flex.Item>
-    </Flex>
-  </Stack>
-);
+const Cards = () => {
+  const navigate = useNavigate();
+  const moveExploreParty = () => navigate("/party-explore");
+
+  return (
+    <Stack space="space03">
+      <Flex gap="12px">
+        <Flex.Item flex="2 1 0">
+          <Box
+            padding="16px"
+            backgroundColor="violet100"
+            borderRadius="15px"
+            height="26dvh"
+            style={{ position: "relative" }}
+          >
+            <Stack>
+              <Typo appearance="body1" color="white">
+                오늘은 어떤 모임이
+              </Typo>
+              <Typo appearance="body1" color="white">
+                있을까요?
+              </Typo>
+              <Flex>
+                <Button
+                  onClick={moveExploreParty}
+                  style={{
+                    width: "50px",
+                    height: "50px",
+                    backgroundColor: "white",
+                    position: "absolute",
+                    bottom: "15px",
+                    left: "15px",
+                  }}
+                >
+                  <IconRightArrow width="30px" />
+                </Button>
+                <IconMascot1
+                  width="100px"
+                  height="100px"
+                  style={{
+                    position: "absolute",
+                    bottom: "30px",
+                    right: "10px",
+                  }}
+                />
+              </Flex>
+            </Stack>
+          </Box>
+        </Flex.Item>
+        <Flex.Item flex="1.6 1 0">
+          <Box
+            padding="16px"
+            backgroundColor="green175"
+            borderRadius="15px"
+            height="26dvh"
+          >
+            <Stack space="space08">
+              <Typo appearance="body1">모임 만들기</Typo>
+              <Box centerContent>
+                <IconMascot3 width={85} height={85} />
+              </Box>
+            </Stack>
+          </Box>
+        </Flex.Item>
+      </Flex>
+      <Flex gap="12px">
+        <Flex.Item flex="1.6 1 0">
+          <Box
+            padding="16px"
+            backgroundColor="green175"
+            borderRadius="15px"
+            height="26dvh"
+          >
+            <Stack space="space08">
+              <Typo appearance="body1">나의 모임</Typo>
+              <Stack align="end">
+                <IconMascot2 width={100} height={100} />
+              </Stack>
+            </Stack>
+          </Box>
+        </Flex.Item>
+        <Flex.Item flex="2 1 0">
+          <Box
+            padding="16px"
+            backgroundColor="violet100"
+            borderRadius="15px"
+            height="26dvh"
+          >
+            <Stack>
+              <Typo appearance="body1" color="white">
+                관심있는 모임
+              </Typo>
+              <Typo appearance="body1" color="white">
+                모아보기
+              </Typo>
+              <Spacing direction="vertical" size="15px" />
+              <IconMascot4 width={88} height={88} />
+            </Stack>
+          </Box>
+        </Flex.Item>
+      </Flex>
+    </Stack>
+  );
+};
 
 const Home = () => {
+  const navigate = useNavigate();
+  const [userInfo, setUserInfo] = useState<AuthResponseData>();
+
+  const onFetchUserInfo = async () => {
+    try {
+      const response = await fetchUserInfo();
+      setUserInfo(response);
+    } catch (error) {
+      console.error("Error while verifying JWT Token", error);
+    }
+  };
+
+  useEffect(() => {
+    onFetchUserInfo();
+  }, []);
+
   return (
     <Box height="100dvh">
       <Flex flexDirection="column">
         <Box padding="0 20px">
           <Header
             leftIcon={<IconJjanLogo width="52px" height="28px" />}
-            rightIcon={<IconAlertEmpty width="20px" height="24px" />}
+            rightIcon={
+              <IconAlertEmpty
+                width="20px"
+                height="24px"
+                onClick={() => navigate("/notifications")}
+              />
+            }
           />
         </Box>
         <Box padding="0 20px" height="100%">
           <Flex flexDirection="column" justifyContent="space-evenly">
             <Flex gap="16px" justifyContent="space-between">
-              <Typo appearance="header1">
-                심심한 오늘, 동네 친구들과 술 한잔 어때요?
-              </Typo>
-              <Avatar width="68px" height="68px" />
+              <Flex.Item flex="1 1 80%">
+                <Typo appearance="header1">
+                  심심한 오늘, 동네 친구들과 술 한잔 어때요?
+                </Typo>
+              </Flex.Item>
+
+              <Flex.Item flex="1 1 20%">
+                {userInfo && userInfo.profile === "blank" ? (
+                  <Box
+                    width="68px"
+                    height="68px"
+                    backgroundColor="gray800"
+                    borderRadius="50%"
+                    overflow="hidden"
+                  />
+                ) : (
+                  <Avatar
+                    isCircle
+                    width="68px"
+                    height="68px"
+                    src={userInfo?.profile}
+                  />
+                )}
+              </Flex.Item>
             </Flex>
             <Cards />
             <Box padding="12px" backgroundColor="gray700" borderRadius="15px">
-              <Flex alignItems="center" justifyContent="space-between">
+              <Flex alignItems="center" gap="20px">
                 <Box>
                   <Flex gap="8px" alignContent="center">
                     <IconLocationPlus width="24px" height="24px" />
                     <Typo appearance="body2">나의 위치</Typo>
                   </Flex>
                 </Box>
-                <Typo appearance="body1">서울특별시 성북구 동선동1가</Typo>
+                <Typo appearance="body1">{userInfo && userInfo.address}</Typo>
               </Flex>
             </Box>
           </Flex>

--- a/src/pages/home/constants.tsx
+++ b/src/pages/home/constants.tsx
@@ -2,7 +2,7 @@ import { IconHome, IconNavigator, IconChat, IconPerson } from "jjan-icon";
 
 const NAV_ITEMS = [
   { url: "/", label: "홈", icon: <IconHome /> },
-  { url: "/finder", label: "탐색하기", icon: <IconNavigator /> },
+  { url: "/party-explore", label: "탐색하기", icon: <IconNavigator /> },
   { url: "/chat", label: "채팅", icon: <IconChat /> },
   { url: "/profile", label: "프로필", icon: <IconPerson /> },
 ];

--- a/src/pages/notifications/Notifications.tsx
+++ b/src/pages/notifications/Notifications.tsx
@@ -1,4 +1,5 @@
 import { IconChevronLeftLarge, IconPeopleGroup } from "jjan-icon";
+import { useNavigate } from "react-router-dom";
 
 import { Layout } from "../components/layout";
 
@@ -56,8 +57,12 @@ const Card = () => {
 };
 
 const Notifications = () => {
+  const navigate = useNavigate();
+
   const HeaderContainer = (
-    <Header leftIcon={<IconChevronLeftLarge />}>알림</Header>
+    <Header leftIcon={<IconChevronLeftLarge onClick={() => navigate(-1)} />}>
+      알림
+    </Header>
   );
   return (
     <Layout header={HeaderContainer}>

--- a/src/pages/party/filter/Filter.tsx
+++ b/src/pages/party/filter/Filter.tsx
@@ -1,5 +1,6 @@
 import { IconChevronLeftLarge } from "jjan-icon";
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 import { LabelCheckBox } from "../../components";
 
@@ -14,6 +15,8 @@ import { Typo } from "@/components/typo";
 import { Layout } from "@/pages/components/layout";
 
 const Filter = () => {
+  const navigate = useNavigate();
+
   const [distance, setDistance] = useState<number>(0);
   const [memberCnt, setMemberCnt] = useState<number>(1);
 
@@ -29,7 +32,13 @@ const Filter = () => {
   };
 
   const HeaderContainer = (
-    <Header leftIcon={<IconChevronLeftLarge />}>필터</Header>
+    <Header
+      leftIcon={
+        <IconChevronLeftLarge onClick={() => navigate("/party-explore")} />
+      }
+    >
+      필터
+    </Header>
   );
 
   return (

--- a/src/pages/signin/SignIn.tsx
+++ b/src/pages/signin/SignIn.tsx
@@ -1,5 +1,4 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useQueryClient } from "@tanstack/react-query";
 import { IconChevronLeftLarge } from "jjan-icon";
 import { useNavigate } from "react-router-dom";
 
@@ -15,12 +14,10 @@ import { Form } from "@/components/form/Form";
 import { Header } from "@/components/header";
 import { Spacing } from "@/components/spacing";
 import { Stack } from "@/components/stack";
-import { QUERY_KEY } from "@/constants/queryKeys";
 
 const Signin = () => {
   const navigate = useNavigate();
   const signinMutation = useSigninApi();
-  const queryClient = useQueryClient();
 
   const handlePrev = () => {
     navigate("/landing", {
@@ -30,11 +27,8 @@ const Signin = () => {
 
   const handleSignin = (data: SigninSchemaType) => {
     signinMutation.mutate(data, {
-      onSuccess: response => {
-        queryClient.setQueryData([QUERY_KEY.user], response.data);
-        navigate("/", {
-          replace: true,
-        });
+      onSuccess: () => {
+        window.location.replace("/");
       },
     });
   };

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,11 +1,14 @@
-import { Suspense } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 
+import { fetchUserInfo } from "./api/jjan/userController";
 import QueryProvider from "./queryProvider";
 
 import { Home } from "@/pages/home";
 import { Landing } from "@/pages/landing";
 import { Loading } from "@/pages/loading";
+import { Notifications } from "@/pages/notifications";
+import { PartyExplore, PartyFiler } from "@/pages/party";
 import { Signin } from "@/pages/signin";
 import { Signup } from "@/pages/signup";
 import { SignupComplete } from "@/pages/signup-complete";
@@ -23,14 +26,41 @@ const authRoutes = () => (
   </Route>
 );
 
-const loggedInRoutes = () => <Route path="/" element={<Home />} />;
+const loggedInRoutes = () => (
+  <>
+    <Route path="/" element={<Home />} />
+    <Route path="/notifications" element={<Notifications />} />
+    <Route path="/party-explore" element={<PartyExplore />} />
+    <Route path="/party-filter" element={<PartyFiler />} />
+  </>
+);
 
 const Router = () => {
-  let token; // 로그인 여부 확인
+  const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
+
+  const onLoggendIn = async () => {
+    try {
+      await fetchUserInfo();
+      setIsLoggedIn(true);
+    } catch (error) {
+      console.error("Error while verifying JWT Token", error);
+      setIsLoggedIn(false);
+    }
+  };
+
+  useEffect(() => {
+    onLoggendIn();
+  }, []);
+
   let routes;
 
-  if (token) {
-    routes = <Routes>{loggedInRoutes()}</Routes>;
+  if (isLoggedIn) {
+    routes = (
+      <Routes>
+        <Route path="/landing" element={<Navigate to="/" />} />
+        {loggedInRoutes()}
+      </Routes>
+    );
   } else {
     routes = (
       <SignupProvider>

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -17,4 +17,11 @@ export const userRoutes = {
   deleteUserUserEmail: "/api/user/:userEmail",
 
   randomNickname: "/api/user/random-nickname",
+
+  userInfo: "/api/user/info",
+};
+
+export const partyRoutes = {
+  getAllParty: "/api/party",
+  getMyParty: "/api/party/my",
 };

--- a/src/theme/foundation/colors.ts
+++ b/src/theme/foundation/colors.ts
@@ -6,6 +6,7 @@ export const colors = {
   gray300: "#4D4D57",
   gray600: "#A6A6B9",
   gray700: "#C4C4C4",
+  gray800: "#D9D9D9",
   green175: "#AFF73C",
   orange300: "#F2822A",
   violet100: "#5B1FD9",

--- a/src/utils/calculateDday.ts
+++ b/src/utils/calculateDday.ts
@@ -1,0 +1,12 @@
+export const calculateDday = (targetDateString: string) => {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const targetDate = new Date(targetDateString);
+  targetDate.setHours(0, 0, 0, 0);
+
+  const diffInMilliseconds = targetDate.getTime() - today.getTime();
+  const diffInDays = diffInMilliseconds / (1000 * 60 * 60 * 24);
+
+  return diffInDays;
+};


### PR DESCRIPTION
# 체크리스트

- [x] 작업 내용이 스프린드 보드에서 할당한 내용과 동일합니다.
- [x] 커밋 메시지가 가이드라인을 따릅니다.
- [x] 코딩 컨벤션 가이드라인을 준수하였습니다.
- [ ] 변경 사항에 대한 테스트가 추가되었습니다.
- [x] 기존의 모든 자동화된 테스트를 통과합니다.

# 설명

token으로 라우팅할 페이지를 동적으로 렌더링하게 구현
react-query로 유저정보를 저장후 useNavigate로 이동시 Router 페이지가 재 렌더링이 안되서 
window.location.replace로 페이지 전환 이떄 새로고침이 발생해 react-query 캐싱이 다 휘발됨

home, explore 페이지 api 코드 결합

# 변경 사항

jjan-icon": "^0.0.6 으로 업데이트
avatar components에 isCircle로 원 속성 추가
PartyCard에 props로 동적으로 텍스트를 렌더링하도록 변경
notification, filter 페이지에 뒤로가기 구현
