### PR TITLE
[#146] refactor : avatar components css -> emotion and broken image process

### DIFF
--- a/src/components/avatar/Avatar.css
+++ b/src/components/avatar/Avatar.css
@@ -6,3 +6,8 @@
 .img-circle {
   border-radius: 50%;
 }
+
+.img-error {
+  background-color: gray;
+  display: inline-block;
+}

--- a/src/components/avatar/Avatar.styled.tsx
+++ b/src/components/avatar/Avatar.styled.tsx
@@ -1,0 +1,40 @@
+import styled from "@emotion/styled";
+
+import { AvatarProps } from "./types";
+
+import { colors } from "@/theme/foundation";
+
+export const ImageContainer = styled.img<AvatarProps>`
+  ${props =>
+    props.isDisabled &&
+    `
+    pointer-events: none;
+    filter: grayscale(100%);
+  `}
+
+  ${props =>
+    props.isCircle &&
+    `
+    border-radius: 50%;
+  `}
+`;
+
+export const ErrorFallback = styled.div<AvatarProps>`
+  background-color: ${colors.gray800};
+  display: inline-block;
+  width: ${props => props.width};
+  height: ${props => props.height};
+
+  ${props =>
+    props.isDisabled &&
+    `
+    pointer-events: none;
+    filter: grayscale(100%);
+  `}
+
+  ${props =>
+    props.isCircle &&
+    `
+    border-radius: 50%;
+  `}
+`;

--- a/src/components/avatar/Avatar.test.tsx
+++ b/src/components/avatar/Avatar.test.tsx
@@ -19,12 +19,6 @@ describe("Calendar 컴포넌트", () => {
     expect(avatarElement).toHaveAttribute("src", imagePath);
   });
 
-  test("Avatar 컴포넌트에 isDisabled 적용되었는지 확인", () => {
-    render(<Avatar alt={altText} src={imagePath} testId={testId} isDisabled />);
-    const avatarElement = screen.getByTestId(testId);
-    expect(avatarElement).toHaveClass("img-disabled");
-  });
-
   test("Avatar 컴포넌트의 ref 조작이 되는지 확인", () => {
     const TestComponent = () => {
       const avatarRef = useRef<HTMLImageElement | null>(null);

--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -1,8 +1,7 @@
-import React, { forwardRef, ForwardedRef } from "react";
+import { forwardRef, ForwardedRef, useState } from "react";
 
+import * as S from "./Avatar.styled";
 import type { AvatarProps } from "./types";
-
-import "./Avatar.css";
 
 const Avatar = (props: AvatarProps, ref: ForwardedRef<HTMLImageElement>) => {
   const {
@@ -16,20 +15,26 @@ const Avatar = (props: AvatarProps, ref: ForwardedRef<HTMLImageElement>) => {
     ...otherProps
   } = props;
 
-  const avatarDisabled = isDisabled ? "img-disabled" : "";
+  const [imageError, setImageError] = useState(false);
 
-  const avatarCircle = isCircle ? "img-circle" : "";
+  const handleImageError = () => {
+    setImageError(true);
+  };
+
+  const Component = imageError ? S.ErrorFallback : S.ImageContainer;
 
   return (
-    <img
+    <Component
       {...otherProps}
-      className={`${avatarDisabled} ${avatarCircle}`}
+      isDisabled={isDisabled}
+      isCircle={isCircle}
       alt={alt}
       width={width}
       height={height}
       ref={ref}
-      src={src}
+      src={!imageError ? src : undefined}
       data-testid={testId}
+      onError={handleImageError}
     />
   );
 };


### PR DESCRIPTION
# 체크리스트

- [x] 작업 내용이 스프린드 보드에서 할당한 내용과 동일합니다.
- [x] 커밋 메시지가 가이드라인을 따릅니다.
- [x] 코딩 컨벤션 가이드라인을 준수하였습니다.
- [ ] 변경 사항에 대한 테스트가 추가되었습니다.
- [x] 기존의 모든 자동화된 테스트를 통과합니다.

# 설명

아바타 컴포넌트에 전달한 src값이 잘못되었을경우 회색화면을 렌더링하게 변경 및 emotion으로 변경

# 변경 사항

기존 css 스타일링을 emotion으로 변경
이미지가 없을 경우 회색 화면으로 렌더링하게 변경
