### PR TITLE
[#150] feat : signup api addition latitude, longitude

### DIFF
--- a/src/pages/signup/address/Address.tsx
+++ b/src/pages/signup/address/Address.tsx
@@ -16,6 +16,8 @@ import { useGeoLocation } from "@/hooks/useGeoLocation";
 import { SignupSubPageProps } from "@/pages/signup/types";
 import {
   setAddress,
+  setLatitude,
+  setLongitude,
   useSignupDispatch,
   useSignupState,
 } from "@/store/signupStore";
@@ -39,6 +41,8 @@ const Address = (props: SignupSubPageProps) => {
 
   const handleNext = () => {
     dispatch(setAddress(value));
+    dispatch(setLatitude(latitude));
+    dispatch(setLongitude(longitude));
     onNextStep();
   };
 

--- a/src/store/signupStore.tsx
+++ b/src/store/signupStore.tsx
@@ -13,6 +13,8 @@ export type State = {
   avatar: File | null;
   gender: GenderState;
   capacity: number;
+  latitude: number;
+  longitude: number;
 };
 
 type Action =
@@ -23,7 +25,9 @@ type Action =
   | { type: "SET_BIRTHDAY"; payload: BirthdayState }
   | { type: "SET_AVATAR"; payload: File }
   | { type: "SET_GENDER"; payload: GenderState }
-  | { type: "SET_CAPACITY"; payload: number };
+  | { type: "SET_CAPACITY"; payload: number }
+  | { type: "SET_LATITUDE"; payload: number }
+  | { type: "SET_LONGITUDE"; payload: number };
 
 export type DispatchType = Dispatch<Action>;
 
@@ -41,6 +45,8 @@ export const initialState: State = {
   avatar: null,
   gender: { label: "남자", value: "남자" },
   capacity: 0,
+  latitude: 0,
+  longitude: 0,
 };
 
 // 액션 생성자 함수 정의
@@ -76,6 +82,14 @@ export const setCapacity = (capacity: number): Action => ({
   type: "SET_CAPACITY",
   payload: capacity,
 });
+export const setLatitude = (latitude: number): Action => ({
+  type: "SET_LATITUDE",
+  payload: latitude,
+});
+export const setLongitude = (longitude: number): Action => ({
+  type: "SET_LONGITUDE",
+  payload: longitude,
+});
 
 // 리듀서 함수 정의
 const signupReducer = (state: State, action: Action): State => {
@@ -96,6 +110,10 @@ const signupReducer = (state: State, action: Action): State => {
       return { ...state, gender: action.payload };
     case "SET_CAPACITY":
       return { ...state, capacity: action.payload };
+    case "SET_LATITUDE":
+      return { ...state, latitude: action.payload };
+    case "SET_LONGITUDE":
+      return { ...state, longitude: action.payload };
     default:
       return state;
   }


### PR DESCRIPTION
# 체크리스트

- [x] 작업 내용이 스프린드 보드에서 할당한 내용과 동일합니다.
- [x] 커밋 메시지가 가이드라인을 따릅니다.
- [x] 코딩 컨벤션 가이드라인을 준수하였습니다.
- [ ] 변경 사항에 대한 테스트가 추가되었습니다.
- [x] 기존의 모든 자동화된 테스트를 통과합니다.

# 설명

기존의 회원가입시에는 도로명만 넘겨주던 방식에서
위도, 경도를 같이 넘겨주도록 변경

# 변경 사항

signupStore에 위도, 경도를 추가 및 action으로 업데이트 가능하도록 수정