### PR TITLE
[#155] feat : connect api create party page

### DIFF
--- a/src/components/selectionbox/Selectionbox.tsx
+++ b/src/components/selectionbox/Selectionbox.tsx
@@ -7,9 +7,11 @@ import { Cluster } from "@/components/cluster";
 import { Typo } from "@/components/typo";
 
 const Selectionbox = (props: SelectionboxProps) => {
-  const { options, onChange } = props;
+  const { options, defaultValues, onChange } = props;
 
-  const [selectedValues, setSelectedValues] = useState<Set<string>>(new Set());
+  const [selectedValues, setSelectedValues] = useState<Set<string>>(
+    defaultValues || new Set(),
+  );
 
   const handleCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const updatedSelectedValues = new Set(selectedValues);

--- a/src/components/selectionbox/types.ts
+++ b/src/components/selectionbox/types.ts
@@ -1,5 +1,6 @@
 type SelectionboxProps = {
   options: string[];
+  defaultValues?: Set<string>;
   onChange?: (values: string[]) => void;
 };
 

--- a/src/pages/create-party/index.ts
+++ b/src/pages/create-party/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./CreateParty";
+export { CreateParty } from "./CreateParty";

--- a/src/pages/create-party/keywords/Keywords.tsx
+++ b/src/pages/create-party/keywords/Keywords.tsx
@@ -1,5 +1,4 @@
 import { IconCancel, IconChevronLeftLarge } from "jjan-icon";
-import { useState } from "react";
 
 import { Box } from "@/components/box";
 import { Button } from "@/components/button";
@@ -43,11 +42,7 @@ const Keywords = (props: PartyFormSubPageProps) => {
   const { curStep, lastStep, onPrevStep, onNextStep } = props;
   const dispatch = usePartyFormDispatch();
 
-  const [selectedKeywords, setSelectedKeywords] = useState(keywords);
-
   const handleNext = () => {
-    dispatch(setKeywords(selectedKeywords));
-
     onNextStep();
   };
 
@@ -74,7 +69,8 @@ const Keywords = (props: PartyFormSubPageProps) => {
         </Stack>
         <Selectionbox
           options={KEYWORDS}
-          onChange={values => setSelectedKeywords(new Set(values))}
+          defaultValues={keywords}
+          onChange={values => dispatch(setKeywords(new Set(values)))}
         />
         <Spacing direction="vertical" fill={true} />
         <Box>

--- a/src/pages/create-party/location/Location.tsx
+++ b/src/pages/create-party/location/Location.tsx
@@ -36,8 +36,10 @@ const Location = (props: PartyFormSubPageProps) => {
   } = useGeoLocation();
 
   const { mapComponent } = useCreateMap({
-    latitude: localLocation?.latitude ? localLocation.latitude : latitude,
-    longitude: localLocation?.longitude ? localLocation.longitude : longitude,
+    latitude: localLocation?.latitude ? localLocation.latitude : latitude || 0,
+    longitude: localLocation?.longitude
+      ? localLocation.longitude
+      : longitude || 0,
     mapLevel: 3,
     mapClickEnabled: false,
     options: {
@@ -76,10 +78,12 @@ const Location = (props: PartyFormSubPageProps) => {
               모임 만들기
             </Header>
             <Stack>
-              <Typo appearance="header1">우리의 모임 이른은?</Typo>
-              <Typo appearance="header1">모임 날짜와 시간을 선택해주세요</Typo>
+              <Typo appearance="header1">어디에서 만날까요?</Typo>
+              <Typo appearance="body1" color="gray700">
+                모임 장소를 정해주세요.
+              </Typo>
             </Stack>
-            {mapComponent()}
+            <Box height="45dvh">{mapComponent()}</Box>
             <Box onClick={() => setShowSearch(prev => !prev)}>
               <Input
                 appearance="underline"

--- a/src/pages/create-party/max-people/MaxPeople.tsx
+++ b/src/pages/create-party/max-people/MaxPeople.tsx
@@ -40,7 +40,7 @@ const MaxPeople = (props: PartyFormSubPageProps) => {
   const [selectedCount, setSelectedCount] = useState(maxPeople);
 
   const handleNext = () => {
-    dispatch(setMaxPeople(selectedCount as number));
+    dispatch(setMaxPeople(selectedCount || ""));
 
     onNextStep();
   };
@@ -69,7 +69,7 @@ const MaxPeople = (props: PartyFormSubPageProps) => {
         <ScrollSelect
           list={PEOPLE_COUNT}
           height={150}
-          onSelectedChange={value => setSelectedCount(value as number)}
+          onSelectedChange={value => setSelectedCount(value as string)}
         />
         <Spacing direction="vertical" fill={true} />
         <Box>

--- a/src/pages/create-party/schedule/Schedule.tsx
+++ b/src/pages/create-party/schedule/Schedule.tsx
@@ -1,6 +1,8 @@
 import { IconCancel, IconChevronLeftLarge } from "jjan-icon";
 import { useState } from "react";
 
+import { generateTimeIncrements } from "./utils";
+
 import { Box } from "@/components/box";
 import { Button } from "@/components/button";
 import { Calendar } from "@/components/calendar";
@@ -50,8 +52,10 @@ const Schedule = (props: PartyFormSubPageProps) => {
           모임 만들기
         </Header>
         <Stack>
-          <Typo appearance="header1">우리의 모임 이른은?</Typo>
-          <Typo appearance="body1">모임 날짜와 시간을 선택해주세요</Typo>
+          <Typo appearance="header1">언제 몇시에 만날까요?</Typo>
+          <Typo appearance="body1" color="gray700">
+            모임 날짜와 시간을 선택해주세요
+          </Typo>
         </Stack>
         <Calendar
           selectedDay={selectedDay}
@@ -60,7 +64,7 @@ const Schedule = (props: PartyFormSubPageProps) => {
           isNextMonth
         />
         <ScrollSelect
-          list={["item1", "item2", "item3"]}
+          list={generateTimeIncrements()}
           height={150}
           onSelectedChange={time => setSelectedTime(time as string)}
         />

--- a/src/pages/create-party/schedule/utils.ts
+++ b/src/pages/create-party/schedule/utils.ts
@@ -1,0 +1,25 @@
+export function generateTimeIncrements() {
+  const currentTime = new Date();
+  const timeArray = [];
+
+  const currentTimeIncrement = new Date(currentTime);
+  const today = currentTimeIncrement.getDay();
+  const tomorrow = today + 1;
+
+  while (currentTimeIncrement.getDay() < tomorrow) {
+    let hours = String(currentTimeIncrement.getHours()).padStart(2, "0");
+    let minutes = String(
+      Math.ceil(currentTimeIncrement.getMinutes() / 10) * 10,
+    ).padStart(2, "0");
+
+    if (minutes === "60") {
+      hours = String((+hours + 1) % 24);
+      minutes = "00";
+    }
+
+    timeArray.push(`${hours}:${minutes}`);
+
+    currentTimeIncrement.setMinutes(currentTimeIncrement.getMinutes() + 10);
+  }
+  return timeArray;
+}

--- a/src/pages/create-party/title/Title.tsx
+++ b/src/pages/create-party/title/Title.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { IconCancel, IconChevronLeftLarge } from "jjan-icon";
 
+import { ACCEPTED_IMAGE_TYPES } from "./constants";
 import { partyImageSchema, PartyImageSchemaType } from "./schema";
 import { UploaderUI } from "./uploaderUi";
 
@@ -74,6 +75,7 @@ const Title = (props: PartyFormSubPageProps) => {
               <Typo appearance="header2">모임 대표 사진</Typo>
               <Form.ImageUploader
                 name="photos"
+                accept={ACCEPTED_IMAGE_TYPES.join(",")}
                 render={props => <UploaderUI {...props} />}
                 mode="multiple"
               />

--- a/src/store/partyStore.tsx
+++ b/src/store/partyStore.tsx
@@ -14,7 +14,7 @@ export type PartyFormState = Partial<{
   date: Date;
   time: string;
   location: PartyLocation;
-  maxPeople: number;
+  maxPeople: string;
   keywords: Set<string>;
 }>;
 
@@ -25,8 +25,9 @@ type Action =
   | { type: "SET_DATE"; payload: Date }
   | { type: "SET_TIME"; payload: string }
   | { type: "SET_LOCATION"; payload: PartyLocation }
-  | { type: "SET_MAX_PEOPLE"; payload: number }
-  | { type: "SET_KEYWORDS"; payload: Set<string> | undefined };
+  | { type: "SET_MAX_PEOPLE"; payload: string }
+  | { type: "SET_KEYWORDS"; payload: Set<string> | undefined }
+  | { type: "CLEAR" };
 
 export type DispatchType = Dispatch<Action>;
 
@@ -65,13 +66,16 @@ export const setLocation = (location: PartyLocation): Action => ({
   type: "SET_LOCATION",
   payload: location,
 });
-export const setMaxPeople = (maxPeople: number): Action => ({
+export const setMaxPeople = (maxPeople: string): Action => ({
   type: "SET_MAX_PEOPLE",
   payload: maxPeople,
 });
 export const setKeywords = (keywords: Set<string> | undefined): Action => ({
   type: "SET_KEYWORDS",
   payload: keywords,
+});
+export const clearStore = (): Action => ({
+  type: "CLEAR",
 });
 
 const partyFormReducer = (
@@ -95,6 +99,8 @@ const partyFormReducer = (
       return { ...state, maxPeople: action.payload };
     case "SET_KEYWORDS":
       return { ...state, keywords: action.payload };
+    case "CLEAR":
+      return { ...initialPartyFormState };
     default:
       return state;
   }


### PR DESCRIPTION
# 체크리스트

- [X] 작업 내용이 스프린드 보드에서 할당한 내용과 동일합니다.
- [X] 커밋 메시지가 가이드라인을 따릅니다.
- [X] 코딩 컨벤션 가이드라인을 준수하였습니다.
- [ ] 변경 사항에 대한 테스트가 추가되었습니다.
- [x] 기존의 모든 자동화된 테스트를 통과합니다.

# 설명

모임 생성 페이지의 UI와 api를 연결하고, 약속 시간을 정하는 로직을 수정하며, 키워드 설정 시 키워드가 입력되지 않았던 버그를 수정합니다.

# 변경 사항

- create-party 페이지에서 useCreateParty 훅을 통한 api 연결
- 약속 시간을 현재 시간 이전의 시간은 출력되지 않게 수정
- 키워드 상태 업데이트를 위해 Selectionbox 컴포넌트 내부 로직 수정

# 관련 이슈

#155 