### PR TITLE
[#161] hotfix : resolve non-api issue in profile edit page

### DIFF
--- a/src/pages/profile/edit/Edit.tsx
+++ b/src/pages/profile/edit/Edit.tsx
@@ -29,7 +29,7 @@ import {
   useUpdateAvatar,
   useUpdateNickname,
   useUpdateDrinkCapacity,
-} from "@/query/user/useUpdateProfile";
+} from "@/query/user";
 
 const HeaderContainer = () => {
   const navigate = useNavigate();
@@ -82,7 +82,7 @@ const Edit = () => {
         mutateAvatar.mutate(formDate);
       }
 
-      mutateDrinkCapacity.mutate(localCapacity);
+      mutateDrinkCapacity.mutate(localCapacity.toString());
     } catch (error) {
       console.error(error);
     }

--- a/src/query/user.ts
+++ b/src/query/user.ts
@@ -1,0 +1,67 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { userRoutes } from "@/routes";
+
+import { JJAN_URL } from "@/api/jjan/domain";
+import { Response } from "@/api/types";
+import { httpService } from "@/module/http";
+import { ErrorType } from "@/module/serverState/type/httpTypes";
+
+// api
+
+function updateUserAvatar(avatar: FormData) {
+  return httpService.patch<Response<null>>(
+    `${JJAN_URL}${userRoutes.updateAvatar}`,
+    avatar,
+    {
+      withCredentials: true,
+    },
+  );
+}
+
+function updateUserNickname(nickname: string) {
+  return httpService.patch<Response<null>>(
+    `${JJAN_URL}${userRoutes.updateNickName}`,
+    {
+      data: nickname,
+    },
+    {
+      withCredentials: true,
+    },
+  );
+}
+
+function updateUserDrinkCapacity(drinkCapacity: string) {
+  return httpService.patch<Response<null>>(
+    `${JJAN_URL}${userRoutes.updateDrinkCapacity}`,
+    {
+      data: drinkCapacity,
+    },
+    {
+      withCredentials: true,
+    },
+  );
+}
+
+// query
+
+export const useUpdateAvatar = () => {
+  return useMutation<Response<null>, ErrorType, FormData>({
+    mutationFn: updateUserAvatar,
+    useErrorBoundary: true,
+  });
+};
+
+export const useUpdateNickname = () => {
+  return useMutation<Response<null>, ErrorType, string>({
+    mutationFn: updateUserNickname,
+    useErrorBoundary: true,
+  });
+};
+
+export const useUpdateDrinkCapacity = () => {
+  return useMutation<Response<null>, ErrorType, string>({
+    mutationFn: updateUserDrinkCapacity,
+    useErrorBoundary: true,
+  });
+};


### PR DESCRIPTION
# 체크리스트

- [x] 작업 내용이 스프린드 보드에서 할당한 내용과 동일합니다.
- [x] 커밋 메시지가 가이드라인을 따릅니다.
- [x] 코딩 컨벤션 가이드라인을 준수하였습니다.
- [ ] 변경 사항에 대한 테스트가 추가되었습니다.
- [x] 기존의 모든 자동화된 테스트를 통과합니다.

# 설명

profile edit 페이지에서 누락된 api를 다시 구현합니다.

# 변경 사항

- api 재작성

# 관련 이슈

#161