### PR TITLE
[#172] feat : add home page move btn party explore fab

### DIFF
--- a/src/pages/components/partyCard/PartyCard.tsx
+++ b/src/pages/components/partyCard/PartyCard.tsx
@@ -84,7 +84,7 @@ const CardImage = ({
       <Box
         width="41px"
         height="18px"
-        backgroundColor="green175"
+        backgroundColor={dDay > -1 ? "green175" : "orange300"}
         style={{
           position: "absolute",
           top: "0",
@@ -93,7 +93,9 @@ const CardImage = ({
           alignItems: "center",
         }}
       >
-        <Typo appearance="info1">{`D-${dDay}`}</Typo>
+        <Typo appearance="info1" color={dDay > -1 ? "black" : "white"}>
+          {dDay > -1 ? `D-${dDay}` : "DONE"}
+        </Typo>
       </Box>
     </Box>
   );

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -8,7 +8,7 @@ import {
   IconMascot3,
   IconMascot4,
 } from "jjan-icon";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 
 import { NAV_ITEMS } from "./constants";
 
@@ -74,36 +74,40 @@ const Cards = () => {
           </Box>
         </Flex.Item>
         <Flex.Item flex="1.6 1 0">
-          <Box
-            padding="16px"
-            backgroundColor="green175"
-            borderRadius="15px"
-            height="26dvh"
-          >
-            <Stack space="space08">
-              <Typo appearance="body1">모임 만들기</Typo>
-              <Box centerContent>
-                <IconMascot3 width={85} height={85} />
-              </Box>
-            </Stack>
-          </Box>
+          <Link to="/party-create">
+            <Box
+              padding="16px"
+              backgroundColor="green175"
+              borderRadius="15px"
+              height="26dvh"
+            >
+              <Stack space="space08">
+                <Typo appearance="body1">모임 만들기</Typo>
+                <Box centerContent>
+                  <IconMascot3 width={85} height={85} />
+                </Box>
+              </Stack>
+            </Box>
+          </Link>
         </Flex.Item>
       </Flex>
       <Flex gap="12px">
         <Flex.Item flex="1.6 1 0">
-          <Box
-            padding="16px"
-            backgroundColor="green175"
-            borderRadius="15px"
-            height="26dvh"
-          >
-            <Stack space="space08">
-              <Typo appearance="body1">나의 모임</Typo>
-              <Stack align="end">
-                <IconMascot2 width={100} height={100} />
+          <Link to="/profile-watchlist">
+            <Box
+              padding="16px"
+              backgroundColor="green175"
+              borderRadius="15px"
+              height="26dvh"
+            >
+              <Stack space="space08">
+                <Typo appearance="body1">나의 모임</Typo>
+                <Stack align="end">
+                  <IconMascot2 width={100} height={100} />
+                </Stack>
               </Stack>
-            </Stack>
-          </Box>
+            </Box>
+          </Link>
         </Flex.Item>
         <Flex.Item flex="2 1 0">
           <Box

--- a/src/pages/party/exit/Exit.tsx
+++ b/src/pages/party/exit/Exit.tsx
@@ -2,7 +2,6 @@ import { IconChevronLeftLarge } from "jjan-icon";
 import { useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
-import { outParty } from "@/api/jjan/partyController";
 import { Box } from "@/components/box";
 import { Button } from "@/components/button";
 import { Header } from "@/components/header";

--- a/src/pages/party/explore/Explore.tsx
+++ b/src/pages/party/explore/Explore.tsx
@@ -125,7 +125,11 @@ const Explore = () => {
               </List>
             </Tabs.Panel>
             <Tabs.Panel name={NAME.SECOND}>
-              <List gap="30px" hideScrollbar>
+              <List
+                gap="30px"
+                height="calc(100dvh - 68px - 198px)"
+                hideScrollbar
+              >
                 {joinedPartyResponse
                   ? joinedPartyResponse.data.map(partyInfo => (
                       <Link

--- a/src/pages/party/explore/Explore.tsx
+++ b/src/pages/party/explore/Explore.tsx
@@ -1,4 +1,4 @@
-import { IconChevronLeftLarge, IconMenu } from "jjan-icon";
+import { IconChevronLeftLarge, IconMenu, IconPensil } from "jjan-icon";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 
 import { NAV_ITEMS } from "../constants";
@@ -7,6 +7,7 @@ import { usePartyFilterData } from "./hooks";
 
 import { BottomNav } from "@/components/bottomNav";
 import { Box } from "@/components/box";
+import { Fab } from "@/components/fab";
 import { Header } from "@/components/header";
 import { Layout } from "@/components/layout";
 import { List } from "@/components/list";
@@ -72,7 +73,18 @@ const Explore = () => {
       footer={<BottomNav items={NAV_ITEMS} />}
       paddingFooter={false}
     >
-      <Box padding="0 20px">
+      <Box padding="0 20px" style={{ position: "relative" }}>
+        <Link to="/party-create">
+          <Fab
+            width="61px"
+            height="61px"
+            location="auto 20 20 auto"
+            boxShadow="0 4px 5px 1px rgba(0, 0, 0, 0.3)"
+            color="white"
+          >
+            <IconPensil width="60%" height="60%" />
+          </Fab>
+        </Link>
         <Stack>
           <Typo appearance="header2" style={{ fontWeight: "bold" }}>
             오늘은 무슨 모임이 있을까요?

--- a/src/pages/party/explore/Explore.tsx
+++ b/src/pages/party/explore/Explore.tsx
@@ -87,7 +87,11 @@ const Explore = () => {
               <Tabs.Tab name={NAME.SECOND}>{NAME.SECOND}</Tabs.Tab>
             </Tabs.List>
             <Tabs.Panel name={NAME.FIRST}>
-              <List gap="30px" height="calc(100dvh - 68px - 198px)" hideScrollbar>
+              <List
+                gap="30px"
+                height="calc(100dvh - 68px - 198px)"
+                hideScrollbar
+              >
                 {partyListToDisplay
                   ? partyListToDisplay.map(partyInfo => (
                       <Link
@@ -110,8 +114,8 @@ const Explore = () => {
             </Tabs.Panel>
             <Tabs.Panel name={NAME.SECOND}>
               <List gap="30px" hideScrollbar>
-                {joinedPartyList
-                  ? joinedPartyList.map(partyInfo => (
+                {joinedPartyResponse
+                  ? joinedPartyResponse.data.map(partyInfo => (
                       <Link
                         to={`/party-detail/${partyInfo.id}`}
                         key={partyInfo.id}

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -4,7 +4,6 @@ import { Route, Routes } from "react-router-dom";
 import { PrivateRoute, PublicRoute, routes } from "./routes";
 
 import { fetchUserInfo } from "@/services/internal/user/http";
-import { SignupProvider } from "@/store/signupStore";
 
 const RouterClient = () => {
   // todo change to useAuth


### PR DESCRIPTION
# 체크리스트

- [x] 작업 내용이 스프린드 보드에서 할당한 내용과 동일합니다.
- [x] 커밋 메시지가 가이드라인을 따릅니다.
- [x] 코딩 컨벤션 가이드라인을 준수하였습니다.
- [ ] 변경 사항에 대한 테스트가 추가되었습니다.
- [x] 기존의 모든 자동화된 테스트를 통과합니다.

# 설명

홈화면의 4가지의 다른 페이지로 이동할수있는 섹션에 각각에 맞는 페이지에 이동할수있도록 Link 컴포넌트를 씌웠습니다.
만약 관심목록을 저장하는 기능이 서버에서 구현이 된다면 해당 페이지를 만들고 마지막 섹션에도 해당 페이지로 이동할수있게 할 예정입니다

모임이 종료되었을떄 dDay를 DONE로 표시하고 배경색을 orange로 표시합니다.

party-explore 화면에서 모임글을 작성할수있는 fab를 추가했습니다.