### PR TITLE
[#178] feat : create skelton UI

### DIFF
--- a/src/components/avatar/Avatar.stories.tsx
+++ b/src/components/avatar/Avatar.stories.tsx
@@ -9,7 +9,19 @@ export default {
 } as Meta;
 
 export const Default = (args: AvatarProps) => {
-  return <Avatar {...args} />;
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "1rem",
+      }}
+    >
+      <Avatar {...args} />
+      <Avatar isLoading width={60} height={60} />
+      <Avatar isLoading width={60} height={60} isCircle />
+    </div>
+  );
 };
 Default.args = {
   alt: "사용자 아바타",

--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -1,5 +1,7 @@
 import { forwardRef, ForwardedRef, useState, useEffect } from "react";
 
+import { Skeleton } from "../skeleton";
+
 import * as S from "./Avatar.styled";
 import type { AvatarProps } from "./types";
 
@@ -12,6 +14,7 @@ const Avatar = (props: AvatarProps, ref: ForwardedRef<HTMLImageElement>) => {
     isCircle = false,
     src,
     testId,
+    isLoading,
     ...otherProps
   } = props;
 
@@ -31,6 +34,12 @@ const Avatar = (props: AvatarProps, ref: ForwardedRef<HTMLImageElement>) => {
   }, [src]);
 
   const Component = imageError ? S.ErrorFallback : S.ImageContainer;
+
+  if (isLoading) {
+    return (
+      <Skeleton width={width} height={height} radius={isCircle ? "50%" : ""} />
+    );
+  }
 
   return (
     <Component

--- a/src/components/avatar/types.ts
+++ b/src/components/avatar/types.ts
@@ -4,8 +4,13 @@ import { BaseTest } from "../types/base";
 
 type ImageBaseProps = ImgHTMLAttributes<HTMLImageElement>;
 
+type SkeletonAvatarProps = {
+  isLoading?: boolean;
+};
+
 type AvatarProps = ImageBaseProps &
-  BaseTest & {
+  BaseTest &
+  SkeletonAvatarProps & {
     isDisabled?: boolean;
     isCircle?: boolean;
   };

--- a/src/components/skeleton/Skeleton.stories.tsx
+++ b/src/components/skeleton/Skeleton.stories.tsx
@@ -1,0 +1,24 @@
+import { Meta } from "@storybook/react";
+
+import { Skeleton } from "./Skeleton";
+
+export default {
+  title: "Skeleton",
+  component: Skeleton,
+} as Meta;
+
+export const Default = () => {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "1rem",
+      }}
+    >
+      <Skeleton width={100} height={100} />
+      <Skeleton width={100} height={100} radius="10px" />
+      <Skeleton width={100} height={100} radius="50%" />
+    </div>
+  );
+};

--- a/src/components/skeleton/Skeleton.style.ts
+++ b/src/components/skeleton/Skeleton.style.ts
@@ -1,0 +1,41 @@
+import styled from "@emotion/styled";
+
+import { SkeletonProps } from "./types";
+
+import { colors } from "@/theme/foundation";
+
+export const Container = styled.div<SkeletonProps>`
+  width: ${props =>
+    typeof props.width === "number" ? `${props.width}px` : props.width};
+  height: ${props =>
+    typeof props.height === "number" ? `${props.height}px` : props.height};
+  box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 12px;
+  border-radius: ${props => props.radius};
+`;
+
+export const Div = styled.div<Pick<SkeletonProps, "radius">>`
+  position: relative;
+  background: ${colors.gray800};
+  border-radius: ${props => props.radius};
+  height: 100%;
+`;
+
+export const Bar = styled.div`
+  position: absolute;
+  left: -100px;
+  width: 40px;
+  height: 100%;
+  background: ${colors.white};
+  transform: rotate(15deg);
+  filter: blur(35px);
+  animation: skeletonMove 1s infinite;
+
+  @keyframes skeletonMove {
+    from {
+      left: -100px;
+    }
+    to {
+      left: calc(100% + 100px);
+    }
+  }
+`;

--- a/src/components/skeleton/Skeleton.style.ts
+++ b/src/components/skeleton/Skeleton.style.ts
@@ -9,13 +9,22 @@ export const Container = styled.div<SkeletonProps>`
     typeof props.width === "number" ? `${props.width}px` : props.width};
   height: ${props =>
     typeof props.height === "number" ? `${props.height}px` : props.height};
-  box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 12px;
   border-radius: ${props => props.radius};
 `;
 
-export const Div = styled.div<Pick<SkeletonProps, "radius">>`
+export const Div = styled.div<Pick<SkeletonProps, "radius" | "trimEdges">>`
   position: relative;
-  background: ${colors.gray800};
+  background: ${props =>
+    props.trimEdges
+      ? `
+  linear-gradient(
+    to bottom,
+    transparent 0%,
+    ${colors.gray800} 15%,
+    ${colors.gray800} 85%,
+    transparent 100%
+  )`
+      : colors.gray800};
   border-radius: ${props => props.radius};
   height: 100%;
 `;

--- a/src/components/skeleton/Skeleton.test.tsx
+++ b/src/components/skeleton/Skeleton.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+
+import { Skeleton } from "./Skeleton";
+
+describe("<Skeleton />", () => {
+  test("should render without crashing", () => {
+    render(<Skeleton width="100px" height="100px" />);
+    const skeleton = screen.getByTestId("skeleton-container");
+    expect(skeleton).toBeInTheDocument();
+  });
+
+  test("should apply width and height from props", () => {
+    render(<Skeleton width={200} height="50%" radius="10px" />);
+    const skeleton = screen.getByTestId("skeleton-container");
+
+    expect(skeleton).toHaveStyle("width: 200px");
+    expect(skeleton).toHaveStyle("height: 50%");
+    expect(skeleton).toHaveStyle("border-radius: 10px");
+  });
+});

--- a/src/components/skeleton/Skeleton.tsx
+++ b/src/components/skeleton/Skeleton.tsx
@@ -1,0 +1,15 @@
+import * as S from "./Skeleton.style";
+import { SkeletonProps } from "./types";
+
+const Skeleton = (props: SkeletonProps) => {
+  const { radius = "0px" } = props;
+  return (
+    <S.Container data-testid="skeleton-container" {...props}>
+      <S.Div radius={radius}>
+        <S.Bar />
+      </S.Div>
+    </S.Container>
+  );
+};
+
+export { Skeleton };

--- a/src/components/skeleton/Skeleton.tsx
+++ b/src/components/skeleton/Skeleton.tsx
@@ -2,10 +2,10 @@ import * as S from "./Skeleton.style";
 import { SkeletonProps } from "./types";
 
 const Skeleton = (props: SkeletonProps) => {
-  const { radius = "0px" } = props;
+  const { radius = "0px", trimEdges = false } = props;
   return (
     <S.Container data-testid="skeleton-container" {...props}>
-      <S.Div radius={radius}>
+      <S.Div radius={radius} trimEdges={trimEdges}>
         <S.Bar />
       </S.Div>
     </S.Container>

--- a/src/components/skeleton/index.ts
+++ b/src/components/skeleton/index.ts
@@ -1,0 +1,1 @@
+export { Skeleton } from "./Skeleton";

--- a/src/components/skeleton/types.ts
+++ b/src/components/skeleton/types.ts
@@ -2,6 +2,7 @@ interface SkeletonProps {
   width: string | number;
   height: string | number;
   radius?: string;
+  trimEdges?: boolean;
 }
 
 export type { SkeletonProps };

--- a/src/components/skeleton/types.ts
+++ b/src/components/skeleton/types.ts
@@ -1,0 +1,7 @@
+interface SkeletonProps {
+  width: string | number;
+  height: string | number;
+  radius?: string;
+}
+
+export type { SkeletonProps };

--- a/src/components/typo/Typo.stories.tsx
+++ b/src/components/typo/Typo.stories.tsx
@@ -56,6 +56,19 @@ export const Default: Story = {
           hello world
         </Typo>
       </div>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "1rem",
+        }}
+      >
+        <Typo isLoading appearance="header1" width="100px" />
+        <Typo isLoading appearance="header2" width="100px" />
+        <Typo isLoading appearance="body1" width="100px" />
+        <Typo isLoading appearance="body2" width="100px" />
+        <Typo isLoading appearance="body3" width="100px" />
+      </div>
     </div>
   ),
 };

--- a/src/components/typo/Typo.tsx
+++ b/src/components/typo/Typo.tsx
@@ -1,16 +1,39 @@
 import React, { forwardRef } from "react";
 
+import { Skeleton } from "../skeleton";
 import { PolymorphicRef } from "../types/polymorphic";
 
 import type { TypoComponent, TypoPropsWithPolymorphic } from "./types";
 import * as S from "./Typo.styles";
+import { getSkeletonAppearanceStyles } from "./utils";
 
 const Typo: TypoComponent = forwardRef(
   <C extends React.ElementType = "span">(
     props: TypoPropsWithPolymorphic<C>,
     ref?: PolymorphicRef<C>,
   ) => {
-    const { as, children, appearance = "body1", ...restProps } = props;
+    const {
+      as,
+      children,
+      appearance = "body1",
+      isLoading,
+      width,
+      ...restProps
+    } = props;
+
+    if (isLoading) {
+      const appearanceStyles = getSkeletonAppearanceStyles(appearance);
+
+      if (appearanceStyles) {
+        return (
+          <Skeleton
+            width={width ? width : "100%"}
+            height={appearanceStyles.height}
+            radius="4px"
+          />
+        );
+      }
+    }
 
     return (
       <S.Typo as={as} ref={ref} appearance={appearance} {...restProps}>

--- a/src/components/typo/Typo.tsx
+++ b/src/components/typo/Typo.tsx
@@ -27,6 +27,7 @@ const Typo: TypoComponent = forwardRef(
       if (appearanceStyles) {
         return (
           <Skeleton
+            trimEdges
             width={width ? width : "100%"}
             height={appearanceStyles.height}
             radius="4px"

--- a/src/components/typo/types.ts
+++ b/src/components/typo/types.ts
@@ -6,10 +6,15 @@ import { Color } from "@/theme/foundation";
 
 type Appearance = "header1" | "header2" | "body1" | "body2" | "body3" | "info1";
 
+type TypoSkeletonProps = {
+  isLoading?: boolean;
+  width?: string;
+};
+
 type TypoProps = {
   appearance: Appearance;
   color?: Color;
-};
+} & TypoSkeletonProps;
 
 type TypoPropsWithPolymorphic<C extends React.ElementType> =
   PolymorphicComponentPropWithRef<C, TypoProps>;

--- a/src/components/typo/utils.ts
+++ b/src/components/typo/utils.ts
@@ -1,0 +1,28 @@
+import { Appearance } from "./types";
+
+import { lineHeight } from "@/theme/foundation";
+
+export const getSkeletonAppearanceStyles = (appearance: Appearance) => {
+  switch (appearance) {
+    case "body1":
+      return {
+        height: lineHeight[25],
+      };
+    case "body2":
+      return {
+        height: lineHeight[23],
+      };
+    case "body3":
+      return {
+        height: lineHeight[20],
+      };
+    case "header1":
+      return {
+        height: lineHeight[31],
+      };
+    case "header2":
+      return {
+        height: lineHeight[28],
+      };
+  }
+};

--- a/src/hooks/usePartyCardRenderer.tsx
+++ b/src/hooks/usePartyCardRenderer.tsx
@@ -1,0 +1,44 @@
+import { Link } from "react-router-dom";
+
+import { PartyCard, PartyCardSkeleton } from "@/pages/components";
+import { PartyInfo } from "@/services/internal/types";
+import { calculateDday } from "@/utils/calculateDday";
+
+const usePartyListRenderer = () => {
+  const handleDday = (date: string) => {
+    const [day] = date.split(" ");
+    return calculateDday(day);
+  };
+
+  const renderPartyCardSkeletons = () =>
+    Array(5)
+      .fill(0)
+      .map((_, index) => <PartyCardSkeleton key={index} />);
+
+  const renderPartyList = (
+    isLoading: boolean,
+    partyData: PartyInfo[] | undefined,
+  ) => {
+    if (isLoading) return renderPartyCardSkeletons();
+
+    if (partyData && partyData.length > 0) {
+      return partyData.map(partyInfo => (
+        <Link to={`/party-detail/${partyInfo.id}`} key={partyInfo.id}>
+          <PartyCard
+            title={partyInfo.title}
+            date={partyInfo.partyDate}
+            partyImage={partyInfo.thumbnail}
+            dDay={handleDday(partyInfo.partyDate)}
+            contributorsAvatars={partyInfo.joinUser.map(user => user.profile)}
+          />
+        </Link>
+      ));
+    } else {
+      return "모임을 찾을 수 없습니다.";
+    }
+  };
+
+  return renderPartyList;
+};
+
+export default usePartyListRenderer;

--- a/src/pages/chat/list/List.tsx
+++ b/src/pages/chat/list/List.tsx
@@ -2,7 +2,11 @@ import { IconChevronLeftLarge, IconMenu } from "jjan-icon";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { RoomListCard, RoomModifyMenu } from "./components";
+import {
+  RoomListCard,
+  RoomModifyMenu,
+  RoomListCardSkeleton,
+} from "./components";
 import { HEADER_BOTTOM_HEIGHT, MENU_HEIGHT } from "./constants";
 
 import { BottomNav } from "@/components/bottomNav";
@@ -28,8 +32,11 @@ const List = () => {
     setCheckedIds(prev => prev.filter(item => item !== id));
   };
 
-  const { data: myChatRoomAllList, refetch: refetchMyChatRoomAllList } =
-    useFetchAllChat();
+  const {
+    data: myChatRoomAllList,
+    refetch: refetchMyChatRoomAllList,
+    isLoading,
+  } = useFetchAllChat();
 
   const handleExitChatRoom = () => {
     if (checkedIds) {
@@ -45,6 +52,11 @@ const List = () => {
       });
     }
   };
+
+  const renderRoomListCardSkeletons = () =>
+    Array(5)
+      .fill(null)
+      .map((_, index) => <RoomListCardSkeleton key={index} />);
 
   return (
     <Layout
@@ -68,15 +80,17 @@ const List = () => {
               : `calc(100dvh - ${HEADER_BOTTOM_HEIGHT}px)`
           }
         >
-          {myChatRoomAllList &&
-            myChatRoomAllList.map((roomData, index) => (
-              <RoomListCard
-                key={index}
-                showMenu={showMenu}
-                roomData={roomData}
-                onCheckChange={handleCheckChange}
-              />
-            ))}
+          {isLoading
+            ? renderRoomListCardSkeletons()
+            : myChatRoomAllList &&
+              myChatRoomAllList.map((roomData, index) => (
+                <RoomListCard
+                  key={index}
+                  showMenu={showMenu}
+                  roomData={roomData}
+                  onCheckChange={handleCheckChange}
+                />
+              ))}
         </ContentList>
       </Box>
       {showMenu && <RoomModifyMenu onClick={handleExitChatRoom} />}

--- a/src/pages/chat/list/components/Card/CardImage.tsx
+++ b/src/pages/chat/list/components/Card/CardImage.tsx
@@ -1,7 +1,17 @@
 import { Avatar } from "@/components/avatar";
 
-const CardImage = ({ partyImages }: { partyImages: string | null }) => {
+const CardImage = ({
+  partyImages,
+  isLoading,
+}: {
+  partyImages?: string | null;
+  isLoading?: boolean;
+}) => {
   const adjustedSrc = partyImages === null ? undefined : partyImages;
+
+  if (isLoading) {
+    return <Avatar width="45px" height="45px" isLoading isCircle />;
+  }
   return <Avatar width="45px" height="45px" isCircle src={adjustedSrc} />;
 };
 

--- a/src/pages/chat/list/components/Card/CardInfo.tsx
+++ b/src/pages/chat/list/components/Card/CardInfo.tsx
@@ -1,13 +1,25 @@
+import { Box } from "@/components/box";
 import { Stack } from "@/components/stack/Stack";
 import { Typo } from "@/components/typo";
 
 const CardInfo = ({
   partyTitle,
   lastChat,
+  isLoading,
 }: {
-  partyTitle: string;
-  lastChat: string | null;
+  partyTitle?: string;
+  lastChat?: string | null;
+  isLoading?: boolean;
 }) => {
+  if (isLoading) {
+    return (
+      <Box width="100%">
+        <Typo isLoading appearance="body2" width="80%" />
+        <Typo isLoading appearance="body3" width="60%" />
+      </Box>
+    );
+  }
+
   return (
     <Stack>
       <Stack>

--- a/src/pages/chat/list/components/Card/RoomListCardSkeleton.tsx
+++ b/src/pages/chat/list/components/Card/RoomListCardSkeleton.tsx
@@ -1,0 +1,20 @@
+import { CardImage } from "./CardImage";
+import { CardInfo } from "./CardInfo";
+
+import { Box } from "@/components/box";
+import { Flex } from "@/components/flex";
+
+const RoomListCardSkeleton = () => (
+  <Box>
+    <Flex gap="18px" alignItems="center">
+      <Flex.Item flex="0 0 10%">
+        <CardImage isLoading />
+      </Flex.Item>
+      <Flex.Item flex="0 0 80%">
+        <CardInfo isLoading />
+      </Flex.Item>
+    </Flex>
+  </Box>
+);
+
+export { RoomListCardSkeleton };

--- a/src/pages/chat/list/components/Card/index.ts
+++ b/src/pages/chat/list/components/Card/index.ts
@@ -1,1 +1,2 @@
 export { RoomListCard } from "./RoomListCard";
+export { RoomListCardSkeleton } from "./RoomListCardSkeleton";

--- a/src/pages/chat/list/components/index.ts
+++ b/src/pages/chat/list/components/index.ts
@@ -1,2 +1,2 @@
-export { RoomListCard } from "./Card";
+export { RoomListCard, RoomListCardSkeleton } from "./Card";
 export { RoomModifyMenu } from "./Menu";

--- a/src/pages/components/createPartyFabButton/CreatePartyFabButton.tsx
+++ b/src/pages/components/createPartyFabButton/CreatePartyFabButton.tsx
@@ -1,0 +1,20 @@
+import { IconPensil } from "jjan-icon";
+import { Link } from "react-router-dom";
+
+import { Fab } from "@/components/fab";
+
+const CreatePartyFabButton = () => (
+  <Link to="/party-create">
+    <Fab
+      width="61px"
+      height="61px"
+      location="auto 20 20 auto"
+      boxShadow="0 4px 5px 1px rgba(0, 0, 0, 0.3)"
+      color="white"
+    >
+      <IconPensil width="60%" height="60%" />
+    </Fab>
+  </Link>
+);
+
+export { CreatePartyFabButton };

--- a/src/pages/components/createPartyFabButton/index.ts
+++ b/src/pages/components/createPartyFabButton/index.ts
@@ -1,0 +1,1 @@
+export { CreatePartyFabButton } from "./CreatePartyFabButton";

--- a/src/pages/components/index.ts
+++ b/src/pages/components/index.ts
@@ -1,2 +1,3 @@
 export { PartyCard, PartyCardSkeleton } from "./partyCard";
 export { LabelCheckBox } from "./labelCheckBox";
+export { CreatePartyFabButton } from "./createPartyFabButton";

--- a/src/pages/components/index.ts
+++ b/src/pages/components/index.ts
@@ -1,2 +1,2 @@
-export { PartyCard } from "./partyCard";
+export { PartyCard, PartyCardSkeleton } from "./partyCard";
 export { LabelCheckBox } from "./labelCheckBox";

--- a/src/pages/components/partyCard/PartyCard.tsx
+++ b/src/pages/components/partyCard/PartyCard.tsx
@@ -5,7 +5,6 @@ import { Avatar } from "@/components/avatar";
 import { Box } from "@/components/box";
 import { Flex } from "@/components/flex";
 import { Spacing } from "@/components/spacing";
-import { Stack } from "@/components/stack";
 import { Typo } from "@/components/typo";
 
 const OverlayedAvatar = ({ overlay, ...avatarProps }: OverlayedAvatarProps) => {
@@ -55,7 +54,7 @@ const CardInfo = ({
   contributorsAvatars,
 }: Pick<PartyCardProps, "title" | "date" | "contributorsAvatars">) => {
   return (
-    <Stack>
+    <Box width="100%">
       <Flex flexDirection="column">
         <Typo
           appearance="body2"
@@ -70,7 +69,7 @@ const CardInfo = ({
         <Spacing direction="vertical" size="20px" />
         <CardContributorsAvatar avatars={contributorsAvatars} />
       </Flex>
-    </Stack>
+    </Box>
   );
 };
 

--- a/src/pages/components/partyCard/PartyCardSkeleton.tsx
+++ b/src/pages/components/partyCard/PartyCardSkeleton.tsx
@@ -1,0 +1,47 @@
+import * as S from "./PartyCard.styles";
+
+import { Avatar } from "@/components/avatar";
+import { Box } from "@/components/box";
+import { Flex } from "@/components/flex";
+import { Spacing } from "@/components/spacing";
+import { Typo } from "@/components/typo";
+
+const CardContributorsAvatarSkeleton = () => (
+  <S.AvatarContainer>
+    {Array(4)
+      .fill(0)
+      .map((_, index) => (
+        <S.AvatarPositioner key={index} index={index}>
+          <Avatar isLoading isCircle width="39px" height="39px" />
+        </S.AvatarPositioner>
+      ))}
+  </S.AvatarContainer>
+);
+
+const CardInfoSkeleton = () => (
+  <Box width="100%">
+    <Flex flexDirection="column">
+      <Typo isLoading appearance="body2" width="80%" />
+      <Typo isLoading appearance="body3" width="60%" />
+      <Spacing direction="vertical" size="20px" />
+      <CardContributorsAvatarSkeleton />
+    </Flex>
+  </Box>
+);
+
+const CardImageSkeleton = () => (
+  <Box width="110px" height="110px">
+    <Avatar isLoading width="110px" height="110px" />
+  </Box>
+);
+
+const PartyCardSkeleton = () => {
+  return (
+    <Flex gap="18px">
+      <CardImageSkeleton />
+      <CardInfoSkeleton />
+    </Flex>
+  );
+};
+
+export { PartyCardSkeleton };

--- a/src/pages/components/partyCard/index.ts
+++ b/src/pages/components/partyCard/index.ts
@@ -1,1 +1,2 @@
 export { PartyCard } from "./PartyCard";
+export { PartyCardSkeleton } from "./PartyCardSkeleton";

--- a/src/pages/party/explore/Explore.tsx
+++ b/src/pages/party/explore/Explore.tsx
@@ -1,9 +1,9 @@
 import { IconChevronLeftLarge, IconMenu } from "jjan-icon";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import { NAV_ITEMS } from "../constants";
 
-import { usePartyFilterData } from "./hooks";
+import { usePartyFilterData, usePartyFilterParams } from "./hooks";
 
 import { BottomNav } from "@/components/bottomNav";
 import { Box } from "@/components/box";
@@ -27,17 +27,21 @@ const NAME = {
 
 const Explore = () => {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
 
-  const sort = searchParams.get("sort");
-  const partyTagListParam = searchParams.get("partyTagList");
-  const partyTagList =
-    partyTagListParam !== null ? JSON.parse(partyTagListParam) : undefined;
-  const radiusRange = searchParams.get("radiusRange");
-  const personnelGoe = searchParams.get("personnelGoe");
-  const personnelLoe = searchParams.get("personnelLoe");
-  const ageTagParam = searchParams.get("ageTag");
-  const ageTag = ageTagParam !== null ? JSON.parse(ageTagParam) : undefined;
+  const { data: allPartyResponse, isLoading: isLoadingAllParty } =
+    useFetchAllParty();
+
+  const { data: joinedPartyResponse, isLoading: isLoadingJoinedParty } =
+    useFetchJoinedParty();
+
+  const {
+    sort,
+    partyTagList,
+    radiusRange,
+    personnelGoe,
+    personnelLoe,
+    ageTag,
+  } = usePartyFilterParams();
 
   const {
     filteredPartyList,
@@ -51,11 +55,6 @@ const Explore = () => {
     personnelLoe,
     ageTag,
   });
-
-  const { data: allPartyResponse, isLoading: isLoadingAllParty } =
-    useFetchAllParty();
-  const { data: joinedPartyResponse, isLoading: isLoadingJoinedParty } =
-    useFetchJoinedParty();
 
   const partyListToDisplay = filteredPartyList?.length
     ? filteredPartyList

--- a/src/pages/party/explore/Explore.tsx
+++ b/src/pages/party/explore/Explore.tsx
@@ -14,13 +14,11 @@ import { List } from "@/components/list";
 import { Stack } from "@/components/stack";
 import { Tabs } from "@/components/tabs";
 import { Typo } from "@/components/typo";
-import { PartyCard, PartyCardSkeleton } from "@/pages/components";
+import usePartyCardRenderer from "@/hooks/usePartyCardRenderer";
 import {
   useFetchAllParty,
   useFetchJoinedParty,
 } from "@/services/internal/party/query";
-import { PartyInfo } from "@/services/internal/types";
-import { calculateDday } from "@/utils/calculateDday";
 
 const NAME = {
   FIRST: "짠 모임",
@@ -53,6 +51,7 @@ const Explore = () => {
     personnelLoe,
     ageTag,
   });
+
   const { data: allPartyResponse, isLoading: isLoadingAllParty } =
     useFetchAllParty();
   const { data: joinedPartyResponse, isLoading: isLoadingJoinedParty } =
@@ -62,42 +61,11 @@ const Explore = () => {
     ? filteredPartyList
     : allPartyResponse && allPartyResponse.data;
 
-  const handleDday = (date: string) => {
-    const [day] = date.split(" ");
-    return calculateDday(day);
-  };
-
   const isLoadingParty =
     (isFilteredPage && isLoadingFilteredParty) ||
     (!isFilteredPage && isLoadingAllParty);
 
-  const renderPartyCardSkeletons = () =>
-    Array(5)
-      .fill(0)
-      .map((_, index) => <PartyCardSkeleton key={index} />);
-
-  const renderPartyList = (
-    isLoading: boolean,
-    partyData: PartyInfo[] | undefined,
-  ) => {
-    if (isLoading) return renderPartyCardSkeletons();
-
-    if (partyData && partyData.length > 0) {
-      return partyData.map(partyInfo => (
-        <Link to={`/party-detail/${partyInfo.id}`} key={partyInfo.id}>
-          <PartyCard
-            title={partyInfo.title}
-            date={partyInfo.partyDate}
-            partyImage={partyInfo.thumbnail}
-            dDay={handleDday(partyInfo.partyDate)}
-            contributorsAvatars={partyInfo.joinUser.map(user => user.profile)}
-          />
-        </Link>
-      ));
-    } else {
-      return "모임을 찾을 수 없습니다.";
-    }
-  };
+  const renderPartyList = usePartyCardRenderer();
 
   return (
     <Layout

--- a/src/pages/party/explore/Explore.tsx
+++ b/src/pages/party/explore/Explore.tsx
@@ -1,5 +1,5 @@
-import { IconChevronLeftLarge, IconMenu, IconPensil } from "jjan-icon";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { IconChevronLeftLarge, IconMenu } from "jjan-icon";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { NAV_ITEMS } from "../constants";
 
@@ -7,7 +7,6 @@ import { usePartyFilterData } from "./hooks";
 
 import { BottomNav } from "@/components/bottomNav";
 import { Box } from "@/components/box";
-import { Fab } from "@/components/fab";
 import { Header } from "@/components/header";
 import { Layout } from "@/components/layout";
 import { List } from "@/components/list";
@@ -15,6 +14,7 @@ import { Stack } from "@/components/stack";
 import { Tabs } from "@/components/tabs";
 import { Typo } from "@/components/typo";
 import usePartyCardRenderer from "@/hooks/usePartyCardRenderer";
+import { CreatePartyFabButton } from "@/pages/components";
 import {
   useFetchAllParty,
   useFetchJoinedParty,
@@ -81,18 +81,8 @@ const Explore = () => {
       paddingFooter={false}
     >
       <Box padding="0 20px" style={{ position: "relative" }}>
-        <Link to="/party-create">
-          <Fab
-            width="61px"
-            height="61px"
-            location="auto 20 20 auto"
-            boxShadow="0 4px 5px 1px rgba(0, 0, 0, 0.3)"
-            color="white"
-          >
-            <IconPensil width="60%" height="60%" />
-          </Fab>
-        </Link>
         <Stack>
+          <CreatePartyFabButton />
           <Typo appearance="header2" style={{ fontWeight: "bold" }}>
             오늘은 무슨 모임이 있을까요?
           </Typo>

--- a/src/pages/party/explore/hooks/index.ts
+++ b/src/pages/party/explore/hooks/index.ts
@@ -1,1 +1,2 @@
 export { usePartyFilterData } from "./usePartyFilterData";
+export { usePartyFilterParams } from "./usePartyFilterParams";

--- a/src/pages/party/explore/hooks/usePartyFilterData.ts
+++ b/src/pages/party/explore/hooks/usePartyFilterData.ts
@@ -12,7 +12,17 @@ export const usePartyFilterData = ({
   ageTag,
 }: FilterPartyRequestData) => {
   const fetchFilterParty = useFetchFilterParty();
+
   const [filteredPartyList, setFilteredPartyList] = useState<PartyInfo[]>();
+
+  const isFilteredPage = !!(
+    sort ||
+    partyTagList ||
+    radiusRange ||
+    personnelGoe ||
+    personnelLoe ||
+    ageTag
+  );
 
   useEffect(() => {
     if (sort) {
@@ -39,5 +49,5 @@ export const usePartyFilterData = ({
     }
   }, []);
 
-  return filteredPartyList;
+  return { filteredPartyList, isFilteredPage, ...fetchFilterParty };
 };

--- a/src/pages/party/explore/hooks/usePartyFilterParams.ts
+++ b/src/pages/party/explore/hooks/usePartyFilterParams.ts
@@ -1,0 +1,21 @@
+import { useSearchParams } from "react-router-dom";
+
+const usePartyFilterParams = () => {
+  const [searchParams] = useSearchParams();
+
+  const getJsonParam = (key: string) => {
+    const param = searchParams.get(key);
+    return param !== null ? JSON.parse(param) : undefined;
+  };
+
+  return {
+    sort: searchParams.get("sort"),
+    partyTagList: getJsonParam("partyTagList"),
+    radiusRange: searchParams.get("radiusRange"),
+    personnelGoe: searchParams.get("personnelGoe"),
+    personnelLoe: searchParams.get("personnelLoe"),
+    ageTag: getJsonParam("ageTag"),
+  };
+};
+
+export { usePartyFilterParams };

--- a/src/pages/profile/watchlist/WatchList.tsx
+++ b/src/pages/profile/watchlist/WatchList.tsx
@@ -1,5 +1,5 @@
 import { IconCancel, IconChevronLeftLarge } from "jjan-icon";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import { Box } from "@/components/box";
 import { Header } from "@/components/header";
@@ -8,10 +8,8 @@ import { Layout } from "@/components/layout";
 import { List } from "@/components/list";
 import { Spacing } from "@/components/spacing";
 import { Typo } from "@/components/typo";
-import { PartyCard } from "@/pages/components";
+import usePartyCardRenderer from "@/hooks/usePartyCardRenderer";
 import { useFetchJoinedParty } from "@/services/internal/party/query";
-import { PartyInfo } from "@/services/internal/types";
-import { calculateDday } from "@/utils/calculateDday";
 
 const HeaderContainer = () => {
   const navigate = useNavigate();
@@ -29,18 +27,9 @@ const HeaderContainer = () => {
 };
 
 const WatchList = () => {
-  let joinedPartyList: PartyInfo[] | undefined;
+  const { data: joinedPartyResponse, isLoading } = useFetchJoinedParty();
 
-  const { data: joinedPartyResponse } = useFetchJoinedParty();
-
-  if (joinedPartyResponse?.data) {
-    joinedPartyList = joinedPartyResponse.data;
-  }
-
-  const handleDday = (date: string) => {
-    const [day] = date.split(" ");
-    return calculateDday(day);
-  };
+  const renderPartyList = usePartyCardRenderer();
 
   return (
     <Layout header={<HeaderContainer />}>
@@ -50,21 +39,7 @@ const WatchList = () => {
         <Hr type="solid" backgroundColor="violet100" />
         <Spacing direction="vertical" size="36px" />
         <List gap="30px" height="calc(100dvh - 68px - 221px)" hideScrollbar>
-          {joinedPartyList
-            ? joinedPartyList.map(partyInfo => (
-                <Link to={`/party-detail/${partyInfo.id}`} key={partyInfo.id}>
-                  <PartyCard
-                    title={partyInfo.title}
-                    date={partyInfo.partyDate}
-                    partyImage={partyInfo.thumbnail}
-                    dDay={handleDday(partyInfo.partyDate)}
-                    contributorsAvatars={partyInfo.joinUser.map(
-                      user => user.profile,
-                    )}
-                  />
-                </Link>
-              ))
-            : "나의 모임을 찾을 수 없습니다."}
+          {renderPartyList(isLoading, joinedPartyResponse?.data)}
         </List>
       </Box>
     </Layout>

--- a/src/services/internal/chat/query.ts
+++ b/src/services/internal/chat/query.ts
@@ -14,4 +14,5 @@ export const useFetchChatMessages = (chatId: string | undefined) =>
 export const useFetchAllChat = () =>
   serverStateManager.fetch<ChatAllRoomResponseData[]>({
     url: `${JJAN_URL}${chatRoutes.getChatAllRoom}`,
+    config: { suspense: false },
   });

--- a/src/services/internal/party/query.ts
+++ b/src/services/internal/party/query.ts
@@ -20,11 +20,13 @@ import { pathToUrl } from "@/utils/pathToURL";
 export const useFetchAllParty = () =>
   serverStateManager.fetch<Response<PartyInfo[]>>({
     url: `${JJAN_URL}${partyRoutes.getAllParty}`,
+    config: { suspense: false },
   });
 
 export const useFetchJoinedParty = () =>
   serverStateManager.fetch<Response<PartyInfo[]>>({
     url: `${JJAN_URL}${partyRoutes.getMyParty}`,
+    config: { suspense: false },
   });
 
 export const useFetchDetailParty = (partyId: string | undefined) =>


### PR DESCRIPTION
# 체크리스트

- [x] 작업 내용이 스프린드 보드에서 할당한 내용과 동일합니다.
- [x] 커밋 메시지가 가이드라인을 따릅니다.
- [x] 코딩 컨벤션 가이드라인을 준수하였습니다.
- [x] 변경 사항에 대한 테스트가 추가되었습니다.
- [x] 기존의 모든 자동화된 테스트를 통과합니다.

# 설명

Skeleton componet 구현 및 Typo, Avatar components들에 isLoading props가 true일 경우 Skeleton을 보여주도록 구현
또한 적절한 space에 Skeleton 적용 ex ) party-explore, chat-list, 관심목록

# 변경 사항

- Avatar component에 Skeleton UI 추가
- Typo component에 Skeleton UI 추가
- party-card를 보여주는 코드를 hooks폴더의 hook으로 분리
- ReactQueryManager에 minimumLoadingTim 메서드로 최소 Loading component display시간 확보 (임시로 만든것이므로 추후 수정가능성 농후)
- party-explore의 fab를 따로 component로 분리
- party-explore의 filter를 적용하기 위해 필요한 search params를 가져오는 코드를 hook으로 분리
- Loading 화면대신 Skeleton을 보여줘야하는 react-query코드에 suspense false 추가
