### PR TITLE
[#179] fix : modify error handleing login on failed login

### DIFF
--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -1,33 +1,66 @@
+import { forwardRef, useEffect, useImperativeHandle } from "react";
+import type { Ref, FormEventHandler } from "react";
 import { useForm, FormProvider } from "react-hook-form";
 import type { FieldValues } from "react-hook-form";
+
+import { Typo } from "../typo";
 
 import { FormInput as Input } from "./formInput";
 import { FormTextarea as Textarea } from "./formTextarea";
 import { ImageUploader } from "./imageUploader";
-import type { FormProps } from "./types";
+import type { FormMethods, FormProps } from "./types";
 
-const FormBase = <TFieldValues extends FieldValues>({
-  children,
-  onSubmit,
-  ...props
-}: FormProps<TFieldValues>) => {
-  const { testId, id } = props;
+const FormBase = forwardRef(
+  <TFieldValues extends FieldValues>(
+    props: FormProps<TFieldValues>,
+    ref?: Ref<FormMethods>,
+  ) => {
+    const { children, onSubmit, testId, id, ...restProps } = props;
+    const methods = useForm<TFieldValues>(restProps);
+    const { isValidating, errors } = methods.formState;
 
-  const methods = useForm<TFieldValues>(props);
+    const handleGlobalError = (error: string) => {
+      methods.setError("root.serverError", { message: error });
+    };
 
-  return (
-    <FormProvider {...methods}>
-      <form
-        id={id}
-        onSubmit={methods.handleSubmit(onSubmit)}
-        data-testid={testId}
-      >
-        {children}
-      </form>
-    </FormProvider>
-  );
-};
+    const handleSubmit: FormEventHandler = e => {
+      e.preventDefault();
+      methods.handleSubmit(onSubmit)();
+      methods.clearErrors();
+    };
 
-const Form = Object.assign(FormBase, { Input, Textarea, ImageUploader });
+    useImperativeHandle(ref, () => ({
+      setGlobalError: handleGlobalError,
+    }));
+
+    useEffect(() => {
+      methods.clearErrors("root.serverError");
+    }, [isValidating, methods]);
+
+    return (
+      <FormProvider {...methods}>
+        <form id={id} onSubmit={handleSubmit} data-testid={testId}>
+          {children}
+        </form>
+        {errors.root?.serverError && (
+          <Typo appearance="body3" color="violet400" role="alert">
+            {errors.root.serverError.message}
+          </Typo>
+        )}
+      </FormProvider>
+    );
+  },
+  /**
+   * @Todo - refactor type assertion
+   */
+) as <TFieldValues extends FieldValues>(
+  props: FormProps<TFieldValues> & { ref?: Ref<FormMethods> },
+) => JSX.Element;
+
+const Form = Object.assign(FormBase, {
+  Input,
+  Textarea,
+  ImageUploader,
+});
 
 export { Form };

--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -1,1 +1,2 @@
 export * from "./types";
+export * from "./Form";

--- a/src/components/form/types.ts
+++ b/src/components/form/types.ts
@@ -3,13 +3,13 @@ import type { FieldValues, SubmitHandler, UseFormProps } from "react-hook-form";
 
 import { BaseTest } from "../types/base";
 
-type ExternalUseFormProps<TFieldValues extends FieldValues> = {
-  onSubmit: SubmitHandler<TFieldValues>;
-};
-
 type FormProps<TFieldValues extends FieldValues> = UseFormProps<TFieldValues> &
   Omit<HTMLAttributes<HTMLFormElement>, "onSubmit"> & {
-    onSubmit: SubmitHandler<TFieldValues>;
+    onSubmit: SubmitHandler<TFieldValues> | ((data: TFieldValues) => void);
   } & BaseTest;
 
-export type { ExternalUseFormProps, FormProps };
+interface FormMethods {
+  setGlobalError: (error: string) => void;
+}
+
+export type { FormProps, FormMethods };

--- a/src/hooks/useFormRef.ts
+++ b/src/hooks/useFormRef.ts
@@ -1,0 +1,40 @@
+import { useRef } from "react";
+
+import type { FormMethods } from "@/components/form";
+
+/**
+ * Form의 ServerSide Error를 다루기 위해 사용될 특수한 훅 입니다.
+ *
+ * @example
+ * ```tsx
+ * function App() {
+ *   const signinFormRef = useFormRef();
+ *   const signinMutation = useSignin();
+ *
+ *   const handleSignin = (data: SigninSchemaType) => {
+ *     signinMutation.mutate(data, {
+ *       onSuccess: () => {
+ *         window.location.replace("/");
+ *       },
+ *       onError: () => {
+ *         signinFormRef.current?.setGlobalError(
+ *           "아이디 또는 비밀번호를 확인해주세요.",
+ *          );
+ *       },
+ *     });
+ *   };
+ *
+ *   return (
+ *     <Form<{ email: string }> onSubmit={handleSignin}>
+ *       <Form.Input type="email" name="email"/>
+ *       <button>Submit</button>
+ *     </Form>
+ *   );
+ * }
+ * ```
+ */
+function useFormRef() {
+  return useRef<FormMethods>(null);
+}
+
+export default useFormRef;

--- a/src/pages/signin/SignIn.tsx
+++ b/src/pages/signin/SignIn.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { IconChevronLeftLarge } from "jjan-icon";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { FORM_DATA } from "./constants";
@@ -12,11 +13,13 @@ import { Form } from "@/components/form/Form";
 import { Header } from "@/components/header";
 import { Layout } from "@/components/layout";
 import { Stack } from "@/components/stack";
+import { Typo } from "@/components/typo";
 import { useSignin } from "@/services/internal/auth/query";
 
 const Signin = () => {
   const navigate = useNavigate();
   const signinMutation = useSignin();
+  const [error, setError] = useState(false);
 
   const handlePrev = () => {
     navigate("/landing", {
@@ -28,6 +31,9 @@ const Signin = () => {
     signinMutation.mutate(data, {
       onSuccess: () => {
         window.location.replace("/");
+      },
+      onError: () => {
+        setError(true);
       },
     });
   };
@@ -72,6 +78,11 @@ const Signin = () => {
               />
             ))}
           </Stack>
+          {error && (
+            <Typo appearance="body3" color="orange300" role="alert">
+              이메일 또는 비밀번호를 확인해주세요.
+            </Typo>
+          )}
         </Form>
       </Box>
     </Layout>

--- a/src/pages/signin/SignIn.tsx
+++ b/src/pages/signin/SignIn.tsx
@@ -1,6 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { IconChevronLeftLarge } from "jjan-icon";
-import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { FORM_DATA } from "./constants";
@@ -13,13 +12,13 @@ import { Form } from "@/components/form/Form";
 import { Header } from "@/components/header";
 import { Layout } from "@/components/layout";
 import { Stack } from "@/components/stack";
-import { Typo } from "@/components/typo";
+import useFormRef from "@/hooks/useFormRef";
 import { useSignin } from "@/services/internal/auth/query";
 
 const Signin = () => {
   const navigate = useNavigate();
   const signinMutation = useSignin();
-  const [error, setError] = useState(false);
+  const signinFormRef = useFormRef();
 
   const handlePrev = () => {
     navigate("/landing", {
@@ -30,10 +29,12 @@ const Signin = () => {
   const handleSignin = (data: SigninSchemaType) => {
     signinMutation.mutate(data, {
       onSuccess: () => {
-        window.location.replace("/");
+        navigate("/");
       },
       onError: () => {
-        setError(true);
+        signinFormRef.current?.setGlobalError(
+          "아이디 또는 비밀번호를 확인해주세요.",
+        );
       },
     });
   };
@@ -60,11 +61,11 @@ const Signin = () => {
       }
     >
       <Box padding="0 20px">
-        <Form
+        <Form<SigninSchemaType>
           onSubmit={handleSignin}
           resolver={zodResolver(signinSchema)}
-          mode="onChange"
           id="signinForm"
+          ref={signinFormRef}
         >
           <Stack space="space08">
             {FORM_DATA.map((input, index) => (
@@ -78,11 +79,6 @@ const Signin = () => {
               />
             ))}
           </Stack>
-          {error && (
-            <Typo appearance="body3" color="orange300" role="alert">
-              이메일 또는 비밀번호를 확인해주세요.
-            </Typo>
-          )}
         </Form>
       </Box>
     </Layout>

--- a/src/services/internal/auth/query.ts
+++ b/src/services/internal/auth/query.ts
@@ -8,7 +8,6 @@ import { serverStateManager } from "@/module/serverState";
 export const useSignin = () =>
   serverStateManager.post({
     url: `${JJAN_URL}${userRoutes.signin}`,
-    config: { useErrorBoundary: true },
   });
 
 export const useSignup = () =>


### PR DESCRIPTION
# 체크리스트

- [X] 작업 내용이 스프린드 보드에서 할당한 내용과 동일합니다.
- [X] 커밋 메시지가 가이드라인을 따릅니다.
- [X] 코딩 컨벤션 가이드라인을 준수하였습니다.
- [ ] 변경 사항에 대한 테스트가 추가되었습니다.
- [X] 기존의 모든 자동화된 테스트를 통과합니다.

# 설명

~~로그인 실패 시 에러 처리를 `ErrorBoundary`에서 수행하는 것이 아닌 직접 페이지에서 수행할 수 있게 수정합니다.~~ 로그인 실패에 대한 에러 처리를 Form 자체적으로 global 에러로 정의하여 처리할 수 있게 수정합니다. 

# 변경 사항

- query에서 `ErrorBoundary` 관련 속성을 false로 변경
- ~로그인 페이지 error 상태 추가 및 관리~
- Fom 컴포넌트의 서버측 에러 상태를 나타내는 `root.serverError`를 설정 및 관리
- `useImperativeHandle` 훅을 이용하여 부모 컴포넌트에서 `setGlobalError` 메서드를 사용
- 기존 `useRef`와 다른 용도로 사용되기 위한 `useFormRef` 훅 생성

# 관련 이슈

#179 
