### PR TITLE
[#188] feat : Automate commit message conventions

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,16 @@
+#!/bin/bash
+. "$(dirname -- "$0")/_/husky.sh"
+
+COMMIT_MESSAGE_FILE_PATH="$1"
+branch_name=$(git symbolic-ref HEAD --short)
+issue_number=$(echo "$branch_name" | grep -o "#[0-9]*" | sed 's/#//')
+
+# 커밋 메시지 앞에 이슈 번호 붙이기
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS에서 실행될 코드
+    sed -i "" "1s/^/[#$issue_number] /" "$COMMIT_MESSAGE_FILE_PATH"
+else
+    # Linux나 Windows(Git Bash)에서 실행될 코드
+    sed -i "1s/^/[#$issue_number] /" "$COMMIT_MESSAGE_FILE_PATH"
+fi
+


### PR DESCRIPTION
# 체크리스트

- [x] 작업 내용이 스프린드 보드에서 할당한 내용과 동일합니다.
- [x] 커밋 메시지가 가이드라인을 따릅니다.
- [x] 코딩 컨벤션 가이드라인을 준수하였습니다.
- [ ] 변경 사항에 대한 테스트가 추가되었습니다.
- [x] 기존의 모든 자동화된 테스트를 통과합니다.

# 설명

commit message title 맨 앞에 자동으로 이슈번호를 붙이도록 구현
