### PR TITLE
[#190] feat : Display neighborhood area on neighborhood verification …

### DIFF
--- a/src/hooks/maps/types.ts
+++ b/src/hooks/maps/types.ts
@@ -1,5 +1,5 @@
 type MarkerOptions = {
-  image: string;
+  image?: string;
   width?: number;
   height?: number;
 } & Partial<Omit<kakao.maps.MarkerOptions, "image">>;

--- a/src/pages/profile/verification/Verification.tsx
+++ b/src/pages/profile/verification/Verification.tsx
@@ -40,12 +40,11 @@ const Verification = () => {
   const { mapComponent } = useCreateMap({
     latitude,
     longitude,
-    mapLevel: 3,
+    mapLevel: 6,
     mapClickEnabled: false,
     options: {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      markerEnabled: true,
+      markerEnabled: {},
+      polygonEnabled: {},
     },
   });
 


### PR DESCRIPTION
# 체크리스트

- [x] 작업 내용이 스프린드 보드에서 할당한 내용과 동일합니다.
- [x] 커밋 메시지가 가이드라인을 따릅니다.
- [x] 코딩 컨벤션 가이드라인을 준수하였습니다.
- [ ] 변경 사항에 대한 테스트가 추가되었습니다.
- [x] 기존의 모든 자동화된 테스트를 통과합니다.

# 설명

동네인증 화면에 동 구역을 폴리곤으로 보여줍니다.

# 변경 사항

- useCreateMap hook의 markerEnabled의 image를 옵셔널하게 변경
- Verification 화면의 useCreateMap의 mapLevel을 6로 변경
